### PR TITLE
feat(iceberg): add table.location sink option to set Iceberg table location on create

### DIFF
--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -336,6 +336,13 @@ pub struct IcebergConfig {
     #[serde(default)]
     pub order_key: Option<String>,
 
+    /// Explicit Iceberg table location used at table creation. When set, it is
+    /// used as `TableCreation.location` directly; otherwise the location is
+    /// derived from `warehouse.path`. Required for catalogs that don't derive a
+    /// location from `warehouse.path`.
+    #[serde(rename = "table.location", default)]
+    pub table_location: Option<String>,
+
     /// Commit every n(>0) checkpoints, default is 60.
     #[serde(default = "iceberg_default_commit_checkpoint_interval")]
     #[serde_as(as = "DisplayFromStr")]
@@ -704,6 +711,15 @@ impl IcebergConfig {
             .table
             .validate()
             .map_err(|e| SinkError::Config(anyhow!(e)))?;
+
+        // The storage catalog ignores `TableCreation.location` and always derives
+        // the table path from `warehouse.path`, so an explicit `table.location`
+        // would be a no-op or produce an inconsistent table. Reject it.
+        if config.table_location.is_some() && config.catalog_type() == "storage" {
+            return Err(SinkError::Config(anyhow!(
+                "`table.location` is not supported with the storage catalog; the location is derived from `warehouse.path`"
+            )));
+        }
 
         if config.write_parquet_max_row_group_rows.is_some() {
             tracing::warn!(

--- a/src/connector/src/sink/iceberg/create_table.rs
+++ b/src/connector/src/sink/iceberg/create_table.rs
@@ -137,7 +137,11 @@ pub(super) async fn create_table_if_not_exists_impl(
             .map_err(|e| SinkError::Iceberg(anyhow!(e)))
             .context("failed to convert arrow schema to iceberg schema")?;
 
-        let location = {
+        let location = if let Some(table_location) = &config.table_location {
+            // An explicit `table.location` takes precedence over the location
+            // derived from `warehouse.path` below.
+            Some(table_location.clone())
+        } else {
             let mut names = namespace.clone().inner();
             names.push(table_name.clone());
             match &config.common.warehouse_path {

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -312,6 +312,7 @@ fn test_parse_iceberg_config() {
             primary_key: Some(vec!["v1".to_owned()]),
             partition_by: Some("v1, identity(v1), truncate(4,v2), bucket(5,v1), year(v3), month(v4), day(v5), hour(v6), void(v1)".to_owned()),
             order_key: None,
+            table_location: None,
             java_catalog_props: [("jdbc.user", "admin"), ("jdbc.password", "123456")]
                 .into_iter()
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
@@ -507,6 +508,73 @@ fn test_parse_google_auth_config() {
     assert_eq!(
         config.common.catalog_header.as_deref(),
         Some("x-goog-user-project=my-gcp-project")
+    );
+}
+
+/// Test that the `table.location` option is parsed, and is `None` when omitted.
+#[test]
+fn test_parse_iceberg_config_table_location() {
+    let values: BTreeMap<String, String> = [
+        ("connector", "iceberg"),
+        ("type", "append-only"),
+        ("force_append_only", "true"),
+        ("catalog.type", "rest"),
+        ("catalog.uri", "http://localhost:8181"),
+        ("warehouse.path", "my_warehouse"),
+        ("table.location", "s3://my-bucket/my_db/my_table"),
+        ("database.name", "my_db"),
+        ("table.name", "my_table"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+    .collect();
+
+    let config = IcebergConfig::from_btreemap(values).unwrap();
+    assert_eq!(
+        config.table_location.as_deref(),
+        Some("s3://my-bucket/my_db/my_table")
+    );
+
+    // When `table.location` is absent, the field stays `None` and parsing is unaffected.
+    let values_without_location: BTreeMap<String, String> = [
+        ("connector", "iceberg"),
+        ("type", "append-only"),
+        ("force_append_only", "true"),
+        ("catalog.type", "rest"),
+        ("catalog.uri", "http://localhost:8181"),
+        ("warehouse.path", "my_warehouse"),
+        ("database.name", "my_db"),
+        ("table.name", "my_table"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+    .collect();
+    let config = IcebergConfig::from_btreemap(values_without_location).unwrap();
+    assert_eq!(config.table_location, None);
+}
+
+/// Test that `table.location` is rejected with the storage catalog, which always
+/// derives the table path from `warehouse.path`.
+#[test]
+fn test_table_location_rejected_for_storage_catalog() {
+    let values: BTreeMap<String, String> = [
+        ("connector", "iceberg"),
+        ("type", "append-only"),
+        ("force_append_only", "true"),
+        ("catalog.type", "storage"),
+        ("warehouse.path", "s3://my-bucket/warehouse"),
+        ("table.location", "s3://my-bucket/elsewhere/my_table"),
+        ("database.name", "my_db"),
+        ("table.name", "my_table"),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_owned(), v.to_owned()))
+    .collect();
+
+    let err = IcebergConfig::from_btreemap(values).unwrap_err();
+    assert!(
+        err.to_string().contains("`table.location` is not supported with the storage catalog"),
+        "unexpected error message: {err}"
     );
 }
 

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -670,6 +670,15 @@ IcebergConfig:
     field_type: String
     required: false
     default: Default::default
+  - name: table.location
+    field_type: String
+    comments: |-
+      Explicit Iceberg table location used at table creation. When set, it is
+      used as `TableCreation.location` directly; otherwise the location is
+      derived from `warehouse.path`. Required for catalogs that don't derive a
+      location from `warehouse.path`.
+    required: false
+    default: Default::default
   - name: commit_checkpoint_interval
     field_type: u64
     comments: Commit every n(>0) checkpoints, default is 60.


### PR DESCRIPTION
Creating an Iceberg table through the sink (create_table_if_not_exists) failed against catalogs whose warehouse.path is not a derivable storage URL — e.g. BigLake/BigQuery REST federation (warehouse.path = bq://...) or a bare REST warehouse name. RisingWave sent the create request with location: null, and the catalog rejected it whenever the target namespace had no default location, leaving no way to create the table from the sink.

TableCreation.location was derived solely from warehouse.path, and for non-URL warehouse paths (bq://, s3tables ARNs, REST warehouse names) that derivation deliberately yields None. The only escape hatch users reached for — putting location=... inside table.properties — feeds Iceberg table metadata properties, never the dedicated TableCreation.location field, so the location never reached the create request.

Added the table.location sink option (IcebergConfig.table_location). When set it is used as TableCreation.location verbatim, taking precedence over the warehouse.path-derived value; the existing request -> JSON -> Java CatalogHandlers.createTable path already serializes location, so no Java change was needed. The storage catalog ignores creation.location and always derives the table path from warehouse.path, so table.location is rejected at config-parse time for catalog.type=storage to avoid a silent no-op or a split metadata/data layout.

- regenerated with_options_sink.yaml for the new option
- fixed the test_parse_iceberg_config struct literal, which was missing commit_checkpoint_size_threshold_mb and no longer compiled