### PR TITLE
fix(cdc): make auto schema change add-only

### DIFF
--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_mysql.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_mysql.slt
@@ -85,7 +85,7 @@ select id,ubig,v1,v2,name from rw_customers order by id;
 1 18446744073709551615 hello 88.9 John
 2 0 hello 88.9 Doe
 
-# rename column on upstream will not be replicated, since we do not support rename column
+# rename/change on upstream is treated as add-only: keep old columns and add new names
 system ok
 mysql -e "
   USE mytest;
@@ -94,7 +94,7 @@ mysql -e "
 "
 
 
-# table schema unchanges, since we reject rename column
+# table schema keeps the old columns and adds the new upstream names
 query TTTT retry 4 backoff 1s
 describe rw_customers;
 ----
@@ -105,6 +105,8 @@ name character varying false NULL
 custinfo jsonb false NULL
 v1 character varying false NULL
 v2 double precision false NULL
+v11 character varying false NULL
+v22 numeric false NULL
 _rw_timestamp timestamp with time zone true NULL
 primary key id NULL NULL
 distribution key id NULL NULL
@@ -128,18 +130,49 @@ mysql -e "
 "
 
 
-# modified column should be dropped
+# upstream dropped columns should be ignored
 query TTTT retry 4 backoff 1s
 describe rw_customers;
 ----
 id bigint false NULL
 ubig numeric false NULL
+modified timestamp without time zone false NULL
 name character varying false NULL
 custinfo jsonb false NULL
+v1 character varying false NULL
+v2 double precision false NULL
+v11 character varying false NULL
+v22 numeric false NULL
 _rw_timestamp timestamp with time zone true NULL
 primary key id NULL NULL
 distribution key id NULL NULL
 table description rw_customers NULL NULL
+
+# add a column after the ignored drop; this should still work instead of failing
+# because the upstream schema is neither a subset nor a superset of the RW schema.
+system ok
+mysql -e "
+  USE mytest;
+  ALTER TABLE customers ADD COLUMN v3 INT DEFAULT 42;
+  INSERT INTO customers (id, ubig, name, custinfo, v3) VALUES (3, 1, 'Smith', NULL, 42);
+"
+
+query TT retry 4 backoff 1s
+select c.name, c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'rw_customers' and c.name in ('modified', 'v1', 'v2', 'v3')
+order by c.name;
+----
+modified timestamp without time zone
+v1 character varying
+v2 double precision
+v3 integer
+
+query ITTTI retry 4 backoff 1s
+select id, modified, v1, v2, v3 from rw_customers where id = 3;
+----
+3 NULL NULL NULL 42
 
 statement ok
 drop source mysql_source cascade;

--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
@@ -190,6 +190,11 @@ drop source pg_source cascade;
 system ok
 psql -c "
     DROP TABLE IF EXISTS test_composite_schema_change;
+    DROP TYPE IF EXISTS money_type;
+    CREATE TYPE money_type AS (
+        currency text,
+        amount numeric
+    );
     CREATE TABLE IF NOT EXISTS test_composite_schema_change(
         id int PRIMARY KEY,
         name varchar(255)

--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
@@ -136,6 +136,8 @@ describe rw_test_schema_change;
 id integer false NULL
 name character varying false NULL
 age integer false NULL
+v1 real false NULL
+v2 double precision false NULL
 v3 numeric false NULL
 v4 boolean false NULL
 v5 date false NULL
@@ -152,15 +154,34 @@ distribution key id NULL NULL
 table description rw_test_schema_change NULL NULL
 
 
-query TTTTTTTTTTTTTTT retry 4 backoff 1s
-SELECT * from rw_test_schema_change order by id;
+query ITTT retry 4 backoff 1s
+SELECT id, v1, v2, v11 from rw_test_schema_change where id = 12;
 ----
-1 name1 20 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-2 name2 21 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-3 name3 22 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-11 aaa 11 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-12 bbb 12 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+12 NULL NULL hello
 
+# add a column after the ignored drop; this should still work instead of failing
+# because the upstream schema is neither a subset nor a superset of the RW schema.
+system ok
+psql -c "
+    ALTER TABLE test_schema_change ADD COLUMN v13 int DEFAULT 13;
+    INSERT INTO test_schema_change (id,name,age) values (13,'ccc', 13);
+"
+
+query TT retry 4 backoff 1s
+select c.name, c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'rw_test_schema_change' and c.name in ('v1', 'v2', 'v13')
+order by c.name;
+----
+v1 real
+v13 integer
+v2 double precision
+
+query ITTTI retry 4 backoff 1s
+SELECT id, v1, v2, v11, v13 from rw_test_schema_change where id = 13;
+----
+13 NULL NULL hello 13
 
 statement ok
 drop source pg_source cascade;

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1346,77 +1346,103 @@ impl DdlService for DdlServiceImpl {
                 .await?;
 
             for table in tables {
-                // Since we only support `ADD` and `DROP` column, we check whether the new columns and the original columns
-                // is a subset of the other.
-                let original_columns: HashSet<(String, DataType)> =
-                    HashSet::from_iter(table.columns.iter().filter_map(|col| {
-                        let col = ColumnCatalog::from(col.clone());
-                        if col.is_generated() || col.is_hidden() {
-                            None
-                        } else {
-                            Some((col.column_desc.name.clone(), col.data_type().clone()))
-                        }
-                    }));
-
-                let mut new_columns: HashSet<(String, DataType)> =
-                    HashSet::from_iter(table_change.columns.iter().filter_map(|col| {
-                        let col = ColumnCatalog::from(col.clone());
-                        if col.is_generated() || col.is_hidden() {
-                            None
-                        } else {
-                            Some((col.column_desc.name.clone(), col.data_type().clone()))
-                        }
-                    }));
-
-                // For subset/superset check, we need to add visible connector additional columns defined by INCLUDE in the original table to new_columns
-                // This includes both _rw columns and user-defined INCLUDE columns (e.g., INCLUDE TIMESTAMP AS xxx)
+                // CDC auto schema change is add-only: keep existing columns and append new ones.
+                let mut original_columns_by_name = HashMap::new();
+                let mut merged_columns = vec![];
+                let mut generated_columns = vec![];
                 for col in &table.columns {
                     let col = ColumnCatalog::from(col.clone());
-                    if col.is_connector_additional_column()
-                        && !col.is_hidden()
-                        && !col.is_generated()
-                    {
-                        new_columns.insert((col.column_desc.name.clone(), col.data_type().clone()));
+                    if !col.is_defined_in_columns_clause() {
+                        continue;
+                    }
+                    if col.is_generated() {
+                        generated_columns.push(col);
+                    } else {
+                        original_columns_by_name
+                            .insert(col.column_desc.name.clone(), col.data_type().clone());
+                        merged_columns.push(col);
                     }
                 }
 
-                if !(original_columns.is_subset(&new_columns)
-                    || original_columns.is_superset(&new_columns))
-                {
+                let mut incoming_column_names = HashSet::new();
+                let mut added_column_names = HashSet::new();
+                for col in &table_change.columns {
+                    let col = ColumnCatalog::from(col.clone());
+                    if col.is_generated() || !col.is_defined_in_columns_clause() {
+                        continue;
+                    }
+
+                    let column_name = col.column_desc.name.clone();
+                    let incoming_type = col.data_type().clone();
+                    incoming_column_names.insert(column_name.clone());
+
+                    match original_columns_by_name.get(&column_name) {
+                        Some(original_type) if original_type == &incoming_type => {}
+                        Some(original_type) => {
+                            tracing::warn!(
+                                target: "auto_schema_change",
+                                table_id = %table.id,
+                                cdc_table_id = table.cdc_table_id,
+                                upstream_ddl = table_change.upstream_ddl,
+                                column = column_name,
+                                original_type = %original_type,
+                                incoming_type = %incoming_type,
+                                "CDC auto schema change does not support changing column type"
+                            );
+                            let fail_info = format!(
+                                "CDC auto schema change does not support changing column type: column {}, original type {}, incoming type {}",
+                                column_name, original_type, incoming_type
+                            );
+                            add_auto_schema_change_fail_event_log(
+                                &self.meta_metrics,
+                                table.id,
+                                table.name.clone(),
+                                table_change.cdc_table_id.clone(),
+                                table_change.upstream_ddl.clone(),
+                                &self.env.event_log_manager_ref(),
+                                fail_info,
+                            );
+                            return Err(Status::invalid_argument(
+                                "CDC auto schema change does not support changing column type",
+                            ));
+                        }
+                        None => {
+                            if added_column_names.insert(column_name) {
+                                merged_columns.push(col);
+                            }
+                        }
+                    }
+                }
+
+                let ignored_drop_columns = original_columns_by_name
+                    .keys()
+                    .filter(|name| !incoming_column_names.contains(*name))
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                if !ignored_drop_columns.is_empty() {
                     tracing::warn!(target: "auto_schema_change",
                                     table_id = %table.id,
                                     cdc_table_id = table.cdc_table_id,
-                                    upstraem_ddl = table_change.upstream_ddl,
-                                    original_columns = ?original_columns,
-                                    new_columns = ?new_columns,
-                                    "New columns should be a subset or superset of the original columns (including hidden columns), since only `ADD COLUMN` and `DROP COLUMN` is supported");
-
-                    let fail_info = "New columns should be a subset or superset of the original columns (including hidden columns), since only `ADD COLUMN` and `DROP COLUMN` is supported".to_owned();
-                    add_auto_schema_change_fail_event_log(
-                        &self.meta_metrics,
-                        table.id,
-                        table.name.clone(),
-                        table_change.cdc_table_id.clone(),
-                        table_change.upstream_ddl.clone(),
-                        &self.env.event_log_manager_ref(),
-                        fail_info,
-                    );
-
-                    return Err(Status::invalid_argument(
-                        "New columns should be a subset or superset of the original columns (including hidden columns)",
-                    ));
+                                    upstream_ddl = table_change.upstream_ddl,
+                                    ignored_columns = ?ignored_drop_columns,
+                                    "ignore upstream dropped columns in CDC auto schema change");
                 }
-                // skip the schema change if there is no change to original columns
-                if original_columns == new_columns {
+
+                // Skip the schema change if there are no new columns to add.
+                if added_column_names.is_empty() {
                     tracing::warn!(target: "auto_schema_change",
                                    table_id = %table.id,
                                    cdc_table_id = table.cdc_table_id,
-                                   upstraem_ddl = table_change.upstream_ddl,
-                                    original_columns = ?original_columns,
-                                    new_columns = ?new_columns,
-                                   "No change to columns, skipping the schema change");
+                                   upstream_ddl = table_change.upstream_ddl,
+                                   "No new columns to add, skipping CDC auto schema change");
                     continue;
                 }
+
+                let mut table_change_for_replace = table_change.clone();
+                merged_columns.extend(generated_columns);
+                table_change_for_replace.columns =
+                    merged_columns.iter().map(|col| col.to_protobuf()).collect();
 
                 let latency_timer = self
                     .meta_metrics
@@ -1429,7 +1455,7 @@ impl DdlService for DdlServiceImpl {
                     .get_table_replace_plan(GetTableReplacePlanRequest {
                         database_id: table.database_id,
                         table_id: table.id,
-                        cdc_table_change: Some(table_change.clone()),
+                        cdc_table_change: Some(table_change_for_replace),
                     })
                     .await;
 
@@ -1469,20 +1495,15 @@ impl DdlService for DdlServiceImpl {
                                         .inc();
                                     latency_timer.observe_duration();
 
-                                    // If any *newly added* column is in the rebackfill_columns list,
+                                    // If any newly added column is in the rebackfill_columns list,
                                     // trigger a full re-backfill so pre-existing rows get the correct
-                                    // values from upstream. We filter against original_columns to avoid
-                                    // false positives from existing columns with expression defaults
-                                    // (e.g. BIGSERIAL nextval()) that are included in every schema change
-                                    // message but do not require re-backfill.
-                                    let original_col_names: HashSet<&str> = original_columns
-                                        .iter()
-                                        .map(|(name, _)| name.as_str())
-                                        .collect();
+                                    // values from upstream. Existing columns with expression defaults
+                                    // can appear in every schema change message but do not require
+                                    // re-backfill.
                                     let needs_rebackfill = table_change
                                         .rebackfill_columns
                                         .iter()
-                                        .any(|col| !original_col_names.contains(col.as_str()));
+                                        .any(|col| added_column_names.contains(col));
                                     if needs_rebackfill {
                                         need_rebackfill = true;
                                         let rw_table_id = table.id;


### PR DESCRIPTION
## Summary

This PR changes CDC auto schema change to support `ADD COLUMN` only.

When an upstream column is dropped, RisingWave now keeps the existing local column and logs the ignored drop. Later upstream `ADD COLUMN` changes can still be applied
normally.

## Motivation

The previous implementation compared the upstream column set with the current RisingWave table column set using subset/superset logic. This worked for simple add/drop
cases, but could permanently block future schema changes.

Example:

1. RisingWave table has columns `(1, 2, 3)`.
2. A downstream materialized view depends on column `3`.
3. Upstream drops column `3`, so the upstream schema becomes `(1, 2)`.
4. RisingWave tries `ALTER TABLE DROP COLUMN 3`, but it fails because the downstream MV depends on it.
5. RisingWave still has `(1, 2, 3)`.
6. Upstream later adds column `4`, so the upstream schema becomes `(1, 2, 4)`.
7. `(1, 2, 4)` is neither a subset nor a superset of `(1, 2, 3)`, so auto schema change keeps failing.