### PR TITLE
fix(cdc): make auto schema change add-only

### DIFF
--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_mysql.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_mysql.slt
@@ -85,7 +85,7 @@ select id,ubig,v1,v2,name from rw_customers order by id;
 1 18446744073709551615 hello 88.9 John
 2 0 hello 88.9 Doe
 
-# rename column on upstream will not be replicated, since we do not support rename column
+# rename/change on upstream is treated as add-only: keep old columns and add new names
 system ok
 mysql -e "
   USE mytest;
@@ -94,7 +94,7 @@ mysql -e "
 "
 
 
-# table schema unchanges, since we reject rename column
+# table schema keeps the old columns and adds the new upstream names
 query TTTT retry 4 backoff 1s
 describe rw_customers;
 ----
@@ -105,6 +105,8 @@ name character varying false NULL
 custinfo jsonb false NULL
 v1 character varying false NULL
 v2 double precision false NULL
+v11 character varying false NULL
+v22 numeric false NULL
 _rw_timestamp timestamp with time zone true NULL
 primary key id NULL NULL
 distribution key id NULL NULL
@@ -128,18 +130,49 @@ mysql -e "
 "
 
 
-# modified column should be dropped
+# upstream dropped columns should be ignored
 query TTTT retry 4 backoff 1s
 describe rw_customers;
 ----
 id bigint false NULL
 ubig numeric false NULL
+modified timestamp without time zone false NULL
 name character varying false NULL
 custinfo jsonb false NULL
+v1 character varying false NULL
+v2 double precision false NULL
+v11 character varying false NULL
+v22 numeric false NULL
 _rw_timestamp timestamp with time zone true NULL
 primary key id NULL NULL
 distribution key id NULL NULL
 table description rw_customers NULL NULL
+
+# add a column after the ignored drop; this should still work instead of failing
+# because the upstream schema is neither a subset nor a superset of the RW schema.
+system ok
+mysql -e "
+  USE mytest;
+  ALTER TABLE customers ADD COLUMN v3 INT DEFAULT 42;
+  INSERT INTO customers (id, ubig, name, custinfo, v3) VALUES (3, 1, 'Smith', NULL, 42);
+"
+
+query TT retry 4 backoff 1s
+select c.name, c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'rw_customers' and c.name in ('modified', 'v1', 'v2', 'v3')
+order by c.name;
+----
+modified timestamp without time zone
+v1 character varying
+v2 double precision
+v3 integer
+
+query ITTTI retry 4 backoff 1s
+select id, modified, v1, v2, v3 from rw_customers where id = 3;
+----
+3 NULL NULL NULL 42
 
 statement ok
 drop source mysql_source cascade;

--- a/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
+++ b/e2e_test/source_legacy/cdc_inline/auto_schema_change_pg.slt
@@ -136,6 +136,8 @@ describe rw_test_schema_change;
 id integer false NULL
 name character varying false NULL
 age integer false NULL
+v1 real false NULL
+v2 double precision false NULL
 v3 numeric false NULL
 v4 boolean false NULL
 v5 date false NULL
@@ -152,15 +154,34 @@ distribution key id NULL NULL
 table description rw_test_schema_change NULL NULL
 
 
-query TTTTTTTTTTTTTTT retry 4 backoff 1s
-SELECT * from rw_test_schema_change order by id;
+query ITTT retry 4 backoff 1s
+SELECT id, v1, v2, v11 from rw_test_schema_change where id = 12;
 ----
-1 name1 20 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-2 name2 21 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-3 name3 22 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-11 aaa 11 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
-12 bbb 12 3.3 f 2020-01-01 12:34:56 <slt:ignore> <slt:ignore> 2020-01-01 12:34:56+00:00 1 day {} hello 1.2345
+12 NULL NULL hello
 
+# add a column after the ignored drop; this should still work instead of failing
+# because the upstream schema is neither a subset nor a superset of the RW schema.
+system ok
+psql -c "
+    ALTER TABLE test_schema_change ADD COLUMN v13 int DEFAULT 13;
+    INSERT INTO test_schema_change (id,name,age) values (13,'ccc', 13);
+"
+
+query TT retry 4 backoff 1s
+select c.name, c.data_type
+from rw_catalog.rw_columns c
+join rw_catalog.rw_tables t on c.relation_id = t.id
+where t.name = 'rw_test_schema_change' and c.name in ('v1', 'v2', 'v13')
+order by c.name;
+----
+v1 real
+v13 integer
+v2 double precision
+
+query ITTTI retry 4 backoff 1s
+SELECT id, v1, v2, v11, v13 from rw_test_schema_change where id = 13;
+----
+13 NULL NULL hello 13
 
 statement ok
 drop source pg_source cascade;

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1356,16 +1356,6 @@ impl DdlService for DdlServiceImpl {
             for table in tables {
                 // Since we only support ADD COLUMN (add-only), we detect new columns
                 // via set difference and detect type changes by checking original columns.
-                let original_columns: HashSet<(String, DataType)> =
-                    HashSet::from_iter(table.columns.iter().filter_map(|col| {
-                        let col = ColumnCatalog::from(col.clone());
-                        if col.is_generated() || col.is_hidden() {
-                            None
-                        } else {
-                            Some((col.column_desc.name.clone(), col.data_type().clone()))
-                        }
-                    }));
-
                 let mut new_columns: HashSet<(String, DataType)> =
                     HashSet::from_iter(table_change.columns.iter().filter_map(|col| {
                         let col = ColumnCatalog::from(col.clone());
@@ -1376,10 +1366,10 @@ impl DdlService for DdlServiceImpl {
                         }
                     }));
 
-                // For difference computation, we need to add visible connector additional columns
-                // defined by INCLUDE in the original table to new_columns.
-                // This includes both _rw columns and user-defined INCLUDE columns
-                // (e.g., INCLUDE TIMESTAMP AS xxx).
+                // Build original columns and add visible connector additional columns
+                // defined by INCLUDE (e.g., INCLUDE TIMESTAMP AS xxx) to new_columns
+                // in a single pass over the existing table columns.
+                let mut original_columns: HashSet<(String, DataType)> = HashSet::new();
                 for col in &table.columns {
                     let col = ColumnCatalog::from(col.clone());
                     if col.is_connector_additional_column()
@@ -1387,6 +1377,10 @@ impl DdlService for DdlServiceImpl {
                         && !col.is_generated()
                     {
                         new_columns.insert((col.column_desc.name.clone(), col.data_type().clone()));
+                    }
+                    if !col.is_generated() && !col.is_hidden() {
+                        original_columns
+                            .insert((col.column_desc.name.clone(), col.data_type().clone()));
                     }
                 }
 

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1356,6 +1356,16 @@ impl DdlService for DdlServiceImpl {
             for table in tables {
                 // Since we only support ADD COLUMN (add-only), we detect new columns
                 // via set difference and detect type changes by checking original columns.
+                let original_columns: HashSet<(String, DataType)> =
+                    HashSet::from_iter(table.columns.iter().filter_map(|col| {
+                        let col = ColumnCatalog::from(col.clone());
+                        if col.is_generated() || col.is_hidden() {
+                            None
+                        } else {
+                            Some((col.column_desc.name.clone(), col.data_type().clone()))
+                        }
+                    }));
+
                 let mut new_columns: HashSet<(String, DataType)> =
                     HashSet::from_iter(table_change.columns.iter().filter_map(|col| {
                         let col = ColumnCatalog::from(col.clone());
@@ -1366,10 +1376,10 @@ impl DdlService for DdlServiceImpl {
                         }
                     }));
 
-                // Build original columns and add visible connector additional columns
-                // defined by INCLUDE (e.g., INCLUDE TIMESTAMP AS xxx) to new_columns
-                // in a single pass over the existing table columns.
-                let mut original_columns: HashSet<(String, DataType)> = HashSet::new();
+                // For difference computation, we need to add visible connector additional columns
+                // defined by INCLUDE in the original table to new_columns.
+                // This includes both _rw columns and user-defined INCLUDE columns
+                // (e.g., INCLUDE TIMESTAMP AS xxx).
                 for col in &table.columns {
                     let col = ColumnCatalog::from(col.clone());
                     if col.is_connector_additional_column()
@@ -1378,13 +1388,9 @@ impl DdlService for DdlServiceImpl {
                     {
                         new_columns.insert((col.column_desc.name.clone(), col.data_type().clone()));
                     }
-                    if !col.is_generated() && !col.is_hidden() {
-                        original_columns
-                            .insert((col.column_desc.name.clone(), col.data_type().clone()));
-                    }
                 }
 
-                let original_type_of: HashMap<&str, &DataType> = original_columns
+                let original_column_types: HashMap<&str, &DataType> = original_columns
                     .iter()
                     .map(|(n, dt)| (n.as_str(), dt))
                     .collect();
@@ -1394,7 +1400,7 @@ impl DdlService for DdlServiceImpl {
                 let mut added_column_names = HashSet::new();
                 for (name, incoming_type) in new_columns.difference(&original_columns) {
                     // Check if this column name already exists with a different type.
-                    if let Some(original_type) = original_type_of.get(name.as_str()) {
+                    if let Some(original_type) = original_column_types.get(name.as_str()) {
                         // Same name, different type → type change is unsupported.
                         tracing::warn!(
                             target: "auto_schema_change",

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1437,7 +1437,7 @@ impl DdlService for DdlServiceImpl {
                 let dropped: Vec<_> = original_columns.difference(&new_columns).collect();
                 if !dropped.is_empty() {
                     self.meta_metrics
-                        .auto_schema_change_drop_ignored_cnt
+                        .auto_schema_change_failure_cnt
                         .with_guarded_label_values(&[&table.id.to_string(), &table.name])
                         .inc();
                     tracing::warn!(target: "auto_schema_change",

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1436,6 +1436,10 @@ impl DdlService for DdlServiceImpl {
                 // Ignore upstream dropped columns via the symmetric set difference.
                 let dropped: Vec<_> = original_columns.difference(&new_columns).collect();
                 if !dropped.is_empty() {
+                    self.meta_metrics
+                        .auto_schema_change_drop_ignored_cnt
+                        .with_guarded_label_values(&[&table.id.to_string(), &table.name])
+                        .inc();
                     tracing::warn!(target: "auto_schema_change",
                                     table_id = %table.id,
                                     cdc_table_id = table.cdc_table_id,

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1390,7 +1390,6 @@ impl DdlService for DdlServiceImpl {
                     }
                 }
 
-                // Pre-build name→type lookup from original columns for O(1) type checks.
                 let original_type_of: HashMap<&str, &DataType> = original_columns
                     .iter()
                     .map(|(n, dt)| (n.as_str(), dt))

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1354,77 +1354,103 @@ impl DdlService for DdlServiceImpl {
                 .await?;
 
             for table in tables {
-                // Since we only support `ADD` and `DROP` column, we check whether the new columns and the original columns
-                // is a subset of the other.
-                let original_columns: HashSet<(String, DataType)> =
-                    HashSet::from_iter(table.columns.iter().filter_map(|col| {
-                        let col = ColumnCatalog::from(col.clone());
-                        if col.is_generated() || col.is_hidden() {
-                            None
-                        } else {
-                            Some((col.column_desc.name.clone(), col.data_type().clone()))
-                        }
-                    }));
-
-                let mut new_columns: HashSet<(String, DataType)> =
-                    HashSet::from_iter(table_change.columns.iter().filter_map(|col| {
-                        let col = ColumnCatalog::from(col.clone());
-                        if col.is_generated() || col.is_hidden() {
-                            None
-                        } else {
-                            Some((col.column_desc.name.clone(), col.data_type().clone()))
-                        }
-                    }));
-
-                // For subset/superset check, we need to add visible connector additional columns defined by INCLUDE in the original table to new_columns
-                // This includes both _rw columns and user-defined INCLUDE columns (e.g., INCLUDE TIMESTAMP AS xxx)
+                // CDC auto schema change is add-only: keep existing columns and append new ones.
+                let mut original_columns_by_name = HashMap::new();
+                let mut merged_columns = vec![];
+                let mut generated_columns = vec![];
                 for col in &table.columns {
                     let col = ColumnCatalog::from(col.clone());
-                    if col.is_connector_additional_column()
-                        && !col.is_hidden()
-                        && !col.is_generated()
-                    {
-                        new_columns.insert((col.column_desc.name.clone(), col.data_type().clone()));
+                    if !col.is_defined_in_columns_clause() {
+                        continue;
+                    }
+                    if col.is_generated() {
+                        generated_columns.push(col);
+                    } else {
+                        original_columns_by_name
+                            .insert(col.column_desc.name.clone(), col.data_type().clone());
+                        merged_columns.push(col);
                     }
                 }
 
-                if !(original_columns.is_subset(&new_columns)
-                    || original_columns.is_superset(&new_columns))
-                {
+                let mut incoming_column_names = HashSet::new();
+                let mut added_column_names = HashSet::new();
+                for col in &table_change.columns {
+                    let col = ColumnCatalog::from(col.clone());
+                    if col.is_generated() || !col.is_defined_in_columns_clause() {
+                        continue;
+                    }
+
+                    let column_name = col.column_desc.name.clone();
+                    let incoming_type = col.data_type().clone();
+                    incoming_column_names.insert(column_name.clone());
+
+                    match original_columns_by_name.get(&column_name) {
+                        Some(original_type) if original_type == &incoming_type => {}
+                        Some(original_type) => {
+                            tracing::warn!(
+                                target: "auto_schema_change",
+                                table_id = %table.id,
+                                cdc_table_id = table.cdc_table_id,
+                                upstream_ddl = table_change.upstream_ddl,
+                                column = column_name,
+                                original_type = %original_type,
+                                incoming_type = %incoming_type,
+                                "CDC auto schema change does not support changing column type"
+                            );
+                            let fail_info = format!(
+                                "CDC auto schema change does not support changing column type: column {}, original type {}, incoming type {}",
+                                column_name, original_type, incoming_type
+                            );
+                            add_auto_schema_change_fail_event_log(
+                                &self.meta_metrics,
+                                table.id,
+                                table.name.clone(),
+                                table_change.cdc_table_id.clone(),
+                                table_change.upstream_ddl.clone(),
+                                &self.env.event_log_manager_ref(),
+                                fail_info,
+                            );
+                            return Err(Status::invalid_argument(
+                                "CDC auto schema change does not support changing column type",
+                            ));
+                        }
+                        None => {
+                            if added_column_names.insert(column_name) {
+                                merged_columns.push(col);
+                            }
+                        }
+                    }
+                }
+
+                let ignored_drop_columns = original_columns_by_name
+                    .keys()
+                    .filter(|name| !incoming_column_names.contains(*name))
+                    .cloned()
+                    .collect::<Vec<_>>();
+
+                if !ignored_drop_columns.is_empty() {
                     tracing::warn!(target: "auto_schema_change",
                                     table_id = %table.id,
                                     cdc_table_id = table.cdc_table_id,
-                                    upstraem_ddl = table_change.upstream_ddl,
-                                    original_columns = ?original_columns,
-                                    new_columns = ?new_columns,
-                                    "New columns should be a subset or superset of the original columns (including hidden columns), since only `ADD COLUMN` and `DROP COLUMN` is supported");
-
-                    let fail_info = "New columns should be a subset or superset of the original columns (including hidden columns), since only `ADD COLUMN` and `DROP COLUMN` is supported".to_owned();
-                    add_auto_schema_change_fail_event_log(
-                        &self.meta_metrics,
-                        table.id,
-                        table.name.clone(),
-                        table_change.cdc_table_id.clone(),
-                        table_change.upstream_ddl.clone(),
-                        &self.env.event_log_manager_ref(),
-                        fail_info,
-                    );
-
-                    return Err(Status::invalid_argument(
-                        "New columns should be a subset or superset of the original columns (including hidden columns)",
-                    ));
+                                    upstream_ddl = table_change.upstream_ddl,
+                                    ignored_columns = ?ignored_drop_columns,
+                                    "ignore upstream dropped columns in CDC auto schema change");
                 }
-                // skip the schema change if there is no change to original columns
-                if original_columns == new_columns {
+
+                // Skip the schema change if there are no new columns to add.
+                if added_column_names.is_empty() {
                     tracing::warn!(target: "auto_schema_change",
                                    table_id = %table.id,
                                    cdc_table_id = table.cdc_table_id,
-                                   upstraem_ddl = table_change.upstream_ddl,
-                                    original_columns = ?original_columns,
-                                    new_columns = ?new_columns,
-                                   "No change to columns, skipping the schema change");
+                                   upstream_ddl = table_change.upstream_ddl,
+                                   "No new columns to add, skipping CDC auto schema change");
                     continue;
                 }
+
+                let mut table_change_for_replace = table_change.clone();
+                merged_columns.extend(generated_columns);
+                table_change_for_replace.columns =
+                    merged_columns.iter().map(|col| col.to_protobuf()).collect();
 
                 let latency_timer = self
                     .meta_metrics
@@ -1437,7 +1463,7 @@ impl DdlService for DdlServiceImpl {
                     .get_table_replace_plan(GetTableReplacePlanRequest {
                         database_id: table.database_id,
                         table_id: table.id,
-                        cdc_table_change: Some(table_change.clone()),
+                        cdc_table_change: Some(table_change_for_replace),
                     })
                     .await;
 

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1390,14 +1390,18 @@ impl DdlService for DdlServiceImpl {
                     }
                 }
 
+                // Pre-build name→type lookup from original columns for O(1) type checks.
+                let original_type_of: HashMap<&str, &DataType> = original_columns
+                    .iter()
+                    .map(|(n, dt)| (n.as_str(), dt))
+                    .collect();
+
                 // Detect new columns and type changes via set difference on the
                 // original (name, type) pairs directly.
                 let mut added_column_names = HashSet::new();
                 for (name, incoming_type) in new_columns.difference(&original_columns) {
                     // Check if this column name already exists with a different type.
-                    if let Some((_, original_type)) =
-                        original_columns.iter().find(|(n, _)| n == name)
-                    {
+                    if let Some(original_type) = original_type_of.get(name.as_str()) {
                         // Same name, different type → type change is unsupported.
                         tracing::warn!(
                             target: "auto_schema_change",

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1354,8 +1354,8 @@ impl DdlService for DdlServiceImpl {
                 .await?;
 
             for table in tables {
-                // CDC auto schema change is add-only: keep existing columns and append new ones.
-                // Build the original columns from the existing table.
+                // Since we only support ADD COLUMN (add-only), we detect new columns
+                // via set difference and detect type changes by checking original columns.
                 let original_columns: HashSet<(String, DataType)> =
                     HashSet::from_iter(table.columns.iter().filter_map(|col| {
                         let col = ColumnCatalog::from(col.clone());
@@ -1376,8 +1376,8 @@ impl DdlService for DdlServiceImpl {
                         }
                     }));
 
-                // Add visible connector additional columns defined by INCLUDE in the original
-                // table to new_columns so they don't appear as dropped.
+                // For difference computation, we need to add visible connector additional columns
+                // defined by INCLUDE in the original table to new_columns.
                 // This includes both _rw columns and user-defined INCLUDE columns
                 // (e.g., INCLUDE TIMESTAMP AS xxx).
                 for col in &table.columns {
@@ -1390,76 +1390,64 @@ impl DdlService for DdlServiceImpl {
                     }
                 }
 
+                // Compute column name sets for set-difference operations.
+                let original_names: HashSet<&str> =
+                    original_columns.iter().map(|(n, _)| n.as_str()).collect();
+                let incoming_names: HashSet<&str> =
+                    new_columns.iter().map(|(n, _)| n.as_str()).collect();
+
                 // Detect column type changes by checking the original columns:
                 // a column with the same name but a different type is unsupported.
-                {
-                    let original_by_name: HashMap<&str, &DataType> = original_columns
+                for (name, incoming_type) in &new_columns {
+                    if let Some(original_type) = original_columns
                         .iter()
-                        .map(|(name, dt)| (name.as_str(), dt))
-                        .collect();
-                    for (name, incoming_type) in &new_columns {
-                        if let Some(original_type) = original_by_name.get(name.as_str()) {
-                            if original_type != &incoming_type {
-                                tracing::warn!(
-                                    target: "auto_schema_change",
-                                    table_id = %table.id,
-                                    cdc_table_id = table.cdc_table_id,
-                                    upstream_ddl = table_change.upstream_ddl,
-                                    column = name,
-                                    original_type = %original_type,
-                                    incoming_type = %incoming_type,
-                                    "CDC auto schema change does not support changing column type"
-                                );
-                                let fail_info = format!(
-                                    "CDC auto schema change does not support changing column type: column {}, original type {}, incoming type {}",
-                                    name, original_type, incoming_type
-                                );
-                                add_auto_schema_change_fail_event_log(
-                                    &self.meta_metrics,
-                                    table.id,
-                                    table.name.clone(),
-                                    table_change.cdc_table_id.clone(),
-                                    table_change.upstream_ddl.clone(),
-                                    &self.env.event_log_manager_ref(),
-                                    fail_info,
-                                );
-                                return Err(Status::invalid_argument(
-                                    "CDC auto schema change does not support changing column type",
-                                ));
-                            }
+                        .find_map(|(n, dt)| if n == name { Some(dt) } else { None })
+                    {
+                        if original_type != incoming_type {
+                            tracing::warn!(
+                                target: "auto_schema_change",
+                                table_id = %table.id,
+                                cdc_table_id = table.cdc_table_id,
+                                upstream_ddl = table_change.upstream_ddl,
+                                column = name,
+                                original_type = %original_type,
+                                incoming_type = %incoming_type,
+                                "CDC auto schema change does not support changing column type"
+                            );
+                            let fail_info = format!(
+                                "CDC auto schema change does not support changing column type: column {}, original type {}, incoming type {}",
+                                name, original_type, incoming_type
+                            );
+                            add_auto_schema_change_fail_event_log(
+                                &self.meta_metrics,
+                                table.id,
+                                table.name.clone(),
+                                table_change.cdc_table_id.clone(),
+                                table_change.upstream_ddl.clone(),
+                                &self.env.event_log_manager_ref(),
+                                fail_info,
+                            );
+                            return Err(Status::invalid_argument(
+                                "CDC auto schema change does not support changing column type",
+                            ));
                         }
                     }
                 }
 
-                // Ignore dropped columns: columns in original but not in incoming.
-                {
-                    let original_names: HashSet<&str> =
-                        original_columns.iter().map(|(name, _)| name.as_str()).collect();
-                    let incoming_names: HashSet<&str> =
-                        new_columns.iter().map(|(name, _)| name.as_str()).collect();
-                    let ignored_drop_columns: Vec<&&str> = original_names
-                        .difference(&incoming_names)
-                        .collect();
-                    if !ignored_drop_columns.is_empty() {
-                        tracing::warn!(target: "auto_schema_change",
-                                        table_id = %table.id,
-                                        cdc_table_id = table.cdc_table_id,
-                                        upstream_ddl = table_change.upstream_ddl,
-                                        ignored_columns = ?ignored_drop_columns,
-                                        "ignore upstream dropped columns in CDC auto schema change");
-                    }
+                // Ignore upstream dropped columns: columns in original but not in incoming.
+                let dropped: Vec<_> = original_names.difference(&incoming_names).collect();
+                if !dropped.is_empty() {
+                    tracing::warn!(target: "auto_schema_change",
+                                    table_id = %table.id,
+                                    cdc_table_id = table.cdc_table_id,
+                                    upstream_ddl = table_change.upstream_ddl,
+                                    ignored_columns = ?dropped,
+                                    "ignore upstream dropped columns in CDC auto schema change");
                 }
 
                 // Detect newly added columns via set difference: new_columns \ original_columns.
-                let added_column_names: HashSet<&str> = {
-                    let original_names: HashSet<&str> =
-                        original_columns.iter().map(|(name, _)| name.as_str()).collect();
-                    new_columns
-                        .iter()
-                        .map(|(name, _)| name.as_str())
-                        .filter(|name| !original_names.contains(name))
-                        .collect()
-                };
+                let added_column_names: HashSet<&str> =
+                    incoming_names.difference(&original_names).copied().collect();
 
                 // Skip the schema change if there are no new columns to add.
                 if added_column_names.is_empty() {
@@ -1473,29 +1461,28 @@ impl DdlService for DdlServiceImpl {
                     continue;
                 }
 
-                // Build merged columns: keep existing columns in the original order,
-                // then append newly added columns from the schema change.
+                // Build merged columns: keep existing columns in original order,
+                // append only the newly added columns from the schema change.
                 let mut merged_columns: Vec<ColumnCatalog> = vec![];
                 for col in &table.columns {
                     let col = ColumnCatalog::from(col.clone());
-                    if col.is_generated() || col.is_hidden() {
-                        continue;
+                    if !col.is_generated() && !col.is_hidden() {
+                        merged_columns.push(col);
                     }
-                    merged_columns.push(col);
                 }
                 for col in &table_change.columns {
                     let col = ColumnCatalog::from(col.clone());
-                    if col.is_generated() || col.is_hidden() {
-                        continue;
-                    }
-                    if added_column_names.contains(col.column_desc.name.as_str()) {
+                    if !col.is_generated()
+                        && !col.is_hidden()
+                        && added_column_names.contains(col.column_desc.name.as_str())
+                    {
                         merged_columns.push(col);
                     }
                 }
 
                 let mut table_change_for_replace = table_change.clone();
                 table_change_for_replace.columns =
-                    merged_columns.iter().map(|col| col.to_protobuf()).collect();
+                    merged_columns.iter().map(|c| c.to_protobuf()).collect();
 
                 let latency_timer = self
                     .meta_metrics

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1390,64 +1390,64 @@ impl DdlService for DdlServiceImpl {
                     }
                 }
 
-                // Compute column name sets for set-difference operations.
-                let original_names: HashSet<&str> =
-                    original_columns.iter().map(|(n, _)| n.as_str()).collect();
-                let incoming_names: HashSet<&str> =
-                    new_columns.iter().map(|(n, _)| n.as_str()).collect();
-
-                // Detect column type changes by checking the original columns:
-                // a column with the same name but a different type is unsupported.
-                for (name, incoming_type) in &new_columns {
-                    if let Some(original_type) = original_columns
-                        .iter()
-                        .find_map(|(n, dt)| if n == name { Some(dt) } else { None })
+                // Detect new columns and type changes via set difference on the
+                // original (name, type) pairs directly.
+                let mut added_column_names = HashSet::new();
+                for (name, incoming_type) in new_columns.difference(&original_columns) {
+                    // Check if this column name already exists with a different type.
+                    if let Some((_, original_type)) =
+                        original_columns.iter().find(|(n, _)| n == name)
                     {
-                        if original_type != incoming_type {
-                            tracing::warn!(
-                                target: "auto_schema_change",
-                                table_id = %table.id,
-                                cdc_table_id = table.cdc_table_id,
-                                upstream_ddl = table_change.upstream_ddl,
-                                column = name,
-                                original_type = %original_type,
-                                incoming_type = %incoming_type,
-                                "CDC auto schema change does not support changing column type"
-                            );
-                            let fail_info = format!(
-                                "CDC auto schema change does not support changing column type: column {}, original type {}, incoming type {}",
-                                name, original_type, incoming_type
-                            );
-                            add_auto_schema_change_fail_event_log(
-                                &self.meta_metrics,
-                                table.id,
-                                table.name.clone(),
-                                table_change.cdc_table_id.clone(),
-                                table_change.upstream_ddl.clone(),
-                                &self.env.event_log_manager_ref(),
-                                fail_info,
-                            );
-                            return Err(Status::invalid_argument(
-                                "CDC auto schema change does not support changing column type",
-                            ));
-                        }
+                        // Same name, different type → type change is unsupported.
+                        tracing::warn!(
+                            target: "auto_schema_change",
+                            table_id = %table.id,
+                            cdc_table_id = table.cdc_table_id,
+                            upstream_ddl = table_change.upstream_ddl,
+                            column = name,
+                            original_type = %original_type,
+                            incoming_type = %incoming_type,
+                            "CDC auto schema change does not support changing column type"
+                        );
+                        let fail_info = format!(
+                            "CDC auto schema change does not support changing column type: column {}, original type {}, incoming type {}",
+                            name, original_type, incoming_type
+                        );
+                        add_auto_schema_change_fail_event_log(
+                            &self.meta_metrics,
+                            table.id,
+                            table.name.clone(),
+                            table_change.cdc_table_id.clone(),
+                            table_change.upstream_ddl.clone(),
+                            &self.env.event_log_manager_ref(),
+                            fail_info,
+                        );
+                        return Err(Status::invalid_argument(
+                            "CDC auto schema change does not support changing column type",
+                        ));
+                    }
+                    // Name not in original → truly new column.
+                    added_column_names.insert(name.as_str());
+                }
+
+                // Ignore upstream dropped columns: names in original but not in incoming.
+                {
+                    let incoming_names: HashSet<&str> =
+                        new_columns.iter().map(|(n, _)| n.as_str()).collect();
+                    let dropped: Vec<_> = original_columns
+                        .iter()
+                        .filter(|(n, _)| !incoming_names.contains(n.as_str()))
+                        .map(|(n, _)| n.as_str())
+                        .collect();
+                    if !dropped.is_empty() {
+                        tracing::warn!(target: "auto_schema_change",
+                                        table_id = %table.id,
+                                        cdc_table_id = table.cdc_table_id,
+                                        upstream_ddl = table_change.upstream_ddl,
+                                        ignored_columns = ?dropped,
+                                        "ignore upstream dropped columns in CDC auto schema change");
                     }
                 }
-
-                // Ignore upstream dropped columns: columns in original but not in incoming.
-                let dropped: Vec<_> = original_names.difference(&incoming_names).collect();
-                if !dropped.is_empty() {
-                    tracing::warn!(target: "auto_schema_change",
-                                    table_id = %table.id,
-                                    cdc_table_id = table.cdc_table_id,
-                                    upstream_ddl = table_change.upstream_ddl,
-                                    ignored_columns = ?dropped,
-                                    "ignore upstream dropped columns in CDC auto schema change");
-                }
-
-                // Detect newly added columns via set difference: new_columns \ original_columns.
-                let added_column_names: HashSet<&str> =
-                    incoming_names.difference(&original_names).copied().collect();
 
                 // Skip the schema change if there are no new columns to add.
                 if added_column_names.is_empty() {

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1355,87 +1355,111 @@ impl DdlService for DdlServiceImpl {
 
             for table in tables {
                 // CDC auto schema change is add-only: keep existing columns and append new ones.
-                let mut original_columns_by_name = HashMap::new();
-                let mut merged_columns = vec![];
-                let mut generated_columns = vec![];
+                // Build the original columns from the existing table.
+                let original_columns: HashSet<(String, DataType)> =
+                    HashSet::from_iter(table.columns.iter().filter_map(|col| {
+                        let col = ColumnCatalog::from(col.clone());
+                        if col.is_generated() || col.is_hidden() {
+                            None
+                        } else {
+                            Some((col.column_desc.name.clone(), col.data_type().clone()))
+                        }
+                    }));
+
+                let mut new_columns: HashSet<(String, DataType)> =
+                    HashSet::from_iter(table_change.columns.iter().filter_map(|col| {
+                        let col = ColumnCatalog::from(col.clone());
+                        if col.is_generated() || col.is_hidden() {
+                            None
+                        } else {
+                            Some((col.column_desc.name.clone(), col.data_type().clone()))
+                        }
+                    }));
+
+                // Add visible connector additional columns defined by INCLUDE in the original
+                // table to new_columns so they don't appear as dropped.
+                // This includes both _rw columns and user-defined INCLUDE columns
+                // (e.g., INCLUDE TIMESTAMP AS xxx).
                 for col in &table.columns {
                     let col = ColumnCatalog::from(col.clone());
-                    if !col.is_defined_in_columns_clause() {
-                        continue;
-                    }
-                    if col.is_generated() {
-                        generated_columns.push(col);
-                    } else {
-                        original_columns_by_name
-                            .insert(col.column_desc.name.clone(), col.data_type().clone());
-                        merged_columns.push(col);
+                    if col.is_connector_additional_column()
+                        && !col.is_hidden()
+                        && !col.is_generated()
+                    {
+                        new_columns.insert((col.column_desc.name.clone(), col.data_type().clone()));
                     }
                 }
 
-                let mut incoming_column_names = HashSet::new();
-                let mut added_column_names = HashSet::new();
-                for col in &table_change.columns {
-                    let col = ColumnCatalog::from(col.clone());
-                    if col.is_generated() || !col.is_defined_in_columns_clause() {
-                        continue;
-                    }
-
-                    let column_name = col.column_desc.name.clone();
-                    let incoming_type = col.data_type().clone();
-                    incoming_column_names.insert(column_name.clone());
-
-                    match original_columns_by_name.get(&column_name) {
-                        Some(original_type) if original_type == &incoming_type => {}
-                        Some(original_type) => {
-                            tracing::warn!(
-                                target: "auto_schema_change",
-                                table_id = %table.id,
-                                cdc_table_id = table.cdc_table_id,
-                                upstream_ddl = table_change.upstream_ddl,
-                                column = column_name,
-                                original_type = %original_type,
-                                incoming_type = %incoming_type,
-                                "CDC auto schema change does not support changing column type"
-                            );
-                            let fail_info = format!(
-                                "CDC auto schema change does not support changing column type: column {}, original type {}, incoming type {}",
-                                column_name, original_type, incoming_type
-                            );
-                            add_auto_schema_change_fail_event_log(
-                                &self.meta_metrics,
-                                table.id,
-                                table.name.clone(),
-                                table_change.cdc_table_id.clone(),
-                                table_change.upstream_ddl.clone(),
-                                &self.env.event_log_manager_ref(),
-                                fail_info,
-                            );
-                            return Err(Status::invalid_argument(
-                                "CDC auto schema change does not support changing column type",
-                            ));
-                        }
-                        None => {
-                            if added_column_names.insert(column_name) {
-                                merged_columns.push(col);
+                // Detect column type changes by checking the original columns:
+                // a column with the same name but a different type is unsupported.
+                {
+                    let original_by_name: HashMap<&str, &DataType> = original_columns
+                        .iter()
+                        .map(|(name, dt)| (name.as_str(), dt))
+                        .collect();
+                    for (name, incoming_type) in &new_columns {
+                        if let Some(original_type) = original_by_name.get(name.as_str()) {
+                            if original_type != &incoming_type {
+                                tracing::warn!(
+                                    target: "auto_schema_change",
+                                    table_id = %table.id,
+                                    cdc_table_id = table.cdc_table_id,
+                                    upstream_ddl = table_change.upstream_ddl,
+                                    column = name,
+                                    original_type = %original_type,
+                                    incoming_type = %incoming_type,
+                                    "CDC auto schema change does not support changing column type"
+                                );
+                                let fail_info = format!(
+                                    "CDC auto schema change does not support changing column type: column {}, original type {}, incoming type {}",
+                                    name, original_type, incoming_type
+                                );
+                                add_auto_schema_change_fail_event_log(
+                                    &self.meta_metrics,
+                                    table.id,
+                                    table.name.clone(),
+                                    table_change.cdc_table_id.clone(),
+                                    table_change.upstream_ddl.clone(),
+                                    &self.env.event_log_manager_ref(),
+                                    fail_info,
+                                );
+                                return Err(Status::invalid_argument(
+                                    "CDC auto schema change does not support changing column type",
+                                ));
                             }
                         }
                     }
                 }
 
-                let ignored_drop_columns = original_columns_by_name
-                    .keys()
-                    .filter(|name| !incoming_column_names.contains(*name))
-                    .cloned()
-                    .collect::<Vec<_>>();
-
-                if !ignored_drop_columns.is_empty() {
-                    tracing::warn!(target: "auto_schema_change",
-                                    table_id = %table.id,
-                                    cdc_table_id = table.cdc_table_id,
-                                    upstream_ddl = table_change.upstream_ddl,
-                                    ignored_columns = ?ignored_drop_columns,
-                                    "ignore upstream dropped columns in CDC auto schema change");
+                // Ignore dropped columns: columns in original but not in incoming.
+                {
+                    let original_names: HashSet<&str> =
+                        original_columns.iter().map(|(name, _)| name.as_str()).collect();
+                    let incoming_names: HashSet<&str> =
+                        new_columns.iter().map(|(name, _)| name.as_str()).collect();
+                    let ignored_drop_columns: Vec<&&str> = original_names
+                        .difference(&incoming_names)
+                        .collect();
+                    if !ignored_drop_columns.is_empty() {
+                        tracing::warn!(target: "auto_schema_change",
+                                        table_id = %table.id,
+                                        cdc_table_id = table.cdc_table_id,
+                                        upstream_ddl = table_change.upstream_ddl,
+                                        ignored_columns = ?ignored_drop_columns,
+                                        "ignore upstream dropped columns in CDC auto schema change");
+                    }
                 }
+
+                // Detect newly added columns via set difference: new_columns \ original_columns.
+                let added_column_names: HashSet<&str> = {
+                    let original_names: HashSet<&str> =
+                        original_columns.iter().map(|(name, _)| name.as_str()).collect();
+                    new_columns
+                        .iter()
+                        .map(|(name, _)| name.as_str())
+                        .filter(|name| !original_names.contains(name))
+                        .collect()
+                };
 
                 // Skip the schema change if there are no new columns to add.
                 if added_column_names.is_empty() {
@@ -1443,12 +1467,33 @@ impl DdlService for DdlServiceImpl {
                                    table_id = %table.id,
                                    cdc_table_id = table.cdc_table_id,
                                    upstream_ddl = table_change.upstream_ddl,
+                                   original_columns = ?original_columns,
+                                   new_columns = ?new_columns,
                                    "No new columns to add, skipping CDC auto schema change");
                     continue;
                 }
 
+                // Build merged columns: keep existing columns in the original order,
+                // then append newly added columns from the schema change.
+                let mut merged_columns: Vec<ColumnCatalog> = vec![];
+                for col in &table.columns {
+                    let col = ColumnCatalog::from(col.clone());
+                    if col.is_generated() || col.is_hidden() {
+                        continue;
+                    }
+                    merged_columns.push(col);
+                }
+                for col in &table_change.columns {
+                    let col = ColumnCatalog::from(col.clone());
+                    if col.is_generated() || col.is_hidden() {
+                        continue;
+                    }
+                    if added_column_names.contains(col.column_desc.name.as_str()) {
+                        merged_columns.push(col);
+                    }
+                }
+
                 let mut table_change_for_replace = table_change.clone();
-                merged_columns.extend(generated_columns);
                 table_change_for_replace.columns =
                     merged_columns.iter().map(|col| col.to_protobuf()).collect();
 

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1433,23 +1433,15 @@ impl DdlService for DdlServiceImpl {
                     added_column_names.insert(name.as_str());
                 }
 
-                // Ignore upstream dropped columns: names in original but not in incoming.
-                {
-                    let incoming_names: HashSet<&str> =
-                        new_columns.iter().map(|(n, _)| n.as_str()).collect();
-                    let dropped: Vec<_> = original_columns
-                        .iter()
-                        .filter(|(n, _)| !incoming_names.contains(n.as_str()))
-                        .map(|(n, _)| n.as_str())
-                        .collect();
-                    if !dropped.is_empty() {
-                        tracing::warn!(target: "auto_schema_change",
-                                        table_id = %table.id,
-                                        cdc_table_id = table.cdc_table_id,
-                                        upstream_ddl = table_change.upstream_ddl,
-                                        ignored_columns = ?dropped,
-                                        "ignore upstream dropped columns in CDC auto schema change");
-                    }
+                // Ignore upstream dropped columns via the symmetric set difference.
+                let dropped: Vec<_> = original_columns.difference(&new_columns).collect();
+                if !dropped.is_empty() {
+                    tracing::warn!(target: "auto_schema_change",
+                                    table_id = %table.id,
+                                    cdc_table_id = table.cdc_table_id,
+                                    upstream_ddl = table_change.upstream_ddl,
+                                    ignored_columns = ?dropped,
+                                    "ignore upstream dropped columns in CDC auto schema change");
                 }
 
                 // Skip the schema change if there are no new columns to add.

--- a/src/meta/service/src/ddl_service.rs
+++ b/src/meta/service/src/ddl_service.rs
@@ -1424,6 +1424,7 @@ impl DdlService for DdlServiceImpl {
                             table_change.upstream_ddl.clone(),
                             &self.env.event_log_manager_ref(),
                             fail_info,
+                            "type_change",
                         );
                         return Err(Status::invalid_argument(
                             "CDC auto schema change does not support changing column type",
@@ -1438,7 +1439,7 @@ impl DdlService for DdlServiceImpl {
                 if !dropped.is_empty() {
                     self.meta_metrics
                         .auto_schema_change_failure_cnt
-                        .with_guarded_label_values(&[&table.id.to_string(), &table.name])
+                        .with_guarded_label_values(&[&table.id.to_string(), &table.name, "ignored_drop"])
                         .inc();
                     tracing::warn!(target: "auto_schema_change",
                                     table_id = %table.id,
@@ -1590,6 +1591,7 @@ impl DdlService for DdlServiceImpl {
                                         table_change.upstream_ddl.clone(),
                                         &self.env.event_log_manager_ref(),
                                         fail_info,
+                                        "replace_failed",
                                     );
                                 }
                             };
@@ -1613,6 +1615,7 @@ impl DdlService for DdlServiceImpl {
                             table_change.upstream_ddl.clone(),
                             &self.env.event_log_manager_ref(),
                             fail_info,
+                            "get_plan_failed",
                         );
                     }
                 };
@@ -1975,10 +1978,11 @@ fn add_auto_schema_change_fail_event_log(
     upstream_ddl: String,
     event_log_manager: &EventLogManagerRef,
     fail_info: String,
+    reason: &str,
 ) {
     meta_metrics
         .auto_schema_change_failure_cnt
-        .with_guarded_label_values(&[&table_id.to_string(), &table_name])
+        .with_guarded_label_values(&[&table_id.to_string(), &table_name, reason])
         .inc();
     let event = event_log::EventAutoSchemaChangeFail {
         table_id,

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -678,7 +678,7 @@ impl MetaMetrics {
         let auto_schema_change_failure_cnt = register_guarded_int_counter_vec_with_registry!(
             "auto_schema_change_failure_cnt",
             "Number of failed auto schema change",
-            &["table_id", "table_name"],
+            &["table_id", "table_name", "reason"],
             registry
         )
         .unwrap();

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -240,6 +240,7 @@ pub struct MetaMetrics {
     // ********************************** Auto Schema Change ************************************
     pub auto_schema_change_failure_cnt: LabelGuardedIntCounterVec,
     pub auto_schema_change_success_cnt: LabelGuardedIntCounterVec,
+    pub auto_schema_change_drop_ignored_cnt: LabelGuardedIntCounterVec,
     pub auto_schema_change_latency: LabelGuardedHistogramVec,
 
     pub time_travel_version_replay_latency: Histogram,
@@ -691,6 +692,14 @@ impl MetaMetrics {
         )
         .unwrap();
 
+        let auto_schema_change_drop_ignored_cnt = register_guarded_int_counter_vec_with_registry!(
+            "auto_schema_change_drop_ignored_cnt",
+            "Number of auto schema change events where upstream dropped columns were ignored",
+            &["table_id", "table_name"],
+            registry
+        )
+        .unwrap();
+
         let opts = histogram_opts!(
             "auto_schema_change_latency",
             "Latency of the auto schema change process",
@@ -1038,6 +1047,7 @@ impl MetaMetrics {
             compaction_event_loop_iteration_latency,
             auto_schema_change_failure_cnt,
             auto_schema_change_success_cnt,
+            auto_schema_change_drop_ignored_cnt,
             auto_schema_change_latency,
             merge_compaction_group_count,
             time_travel_version_replay_latency,

--- a/src/meta/src/rpc/metrics.rs
+++ b/src/meta/src/rpc/metrics.rs
@@ -240,7 +240,6 @@ pub struct MetaMetrics {
     // ********************************** Auto Schema Change ************************************
     pub auto_schema_change_failure_cnt: LabelGuardedIntCounterVec,
     pub auto_schema_change_success_cnt: LabelGuardedIntCounterVec,
-    pub auto_schema_change_drop_ignored_cnt: LabelGuardedIntCounterVec,
     pub auto_schema_change_latency: LabelGuardedHistogramVec,
 
     pub time_travel_version_replay_latency: Histogram,
@@ -692,14 +691,6 @@ impl MetaMetrics {
         )
         .unwrap();
 
-        let auto_schema_change_drop_ignored_cnt = register_guarded_int_counter_vec_with_registry!(
-            "auto_schema_change_drop_ignored_cnt",
-            "Number of auto schema change events where upstream dropped columns were ignored",
-            &["table_id", "table_name"],
-            registry
-        )
-        .unwrap();
-
         let opts = histogram_opts!(
             "auto_schema_change_latency",
             "Latency of the auto schema change process",
@@ -1047,7 +1038,6 @@ impl MetaMetrics {
             compaction_event_loop_iteration_latency,
             auto_schema_change_failure_cnt,
             auto_schema_change_success_cnt,
-            auto_schema_change_drop_ignored_cnt,
             auto_schema_change_latency,
             merge_compaction_group_count,
             time_travel_version_replay_latency,


### PR DESCRIPTION
## Summary

This PR changes CDC auto schema change to support `ADD COLUMN` only.

When an upstream column is dropped, RisingWave now keeps the existing local column and logs the ignored drop. Later upstream `ADD COLUMN` changes can still be applied
normally.

## Motivation

The previous implementation compared the upstream column set with the current RisingWave table column set using subset/superset logic. This worked for simple add/drop
cases, but could permanently block future schema changes.

Example:

1. RisingWave table has columns `(1, 2, 3)`.
2. A downstream materialized view depends on column `3`.
3. Upstream drops column `3`, so the upstream schema becomes `(1, 2)`.
4. RisingWave tries `ALTER TABLE DROP COLUMN 3`, but it fails because the downstream MV depends on it.
5. RisingWave still has `(1, 2, 3)`.
6. Upstream later adds column `4`, so the upstream schema becomes `(1, 2, 4)`.
7. `(1, 2, 4)` is neither a subset nor a superset of `(1, 2, 3)`, so auto schema change keeps failing.