### PR TITLE
fix(cdc): handle Postgres array values and TOAST sentinels in CDC

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/resources/postgres.properties
+++ b/java/connector-node/risingwave-connector-service/src/main/resources/postgres.properties
@@ -1,8 +1,9 @@
 # configs for postgres conneoctor
 connector.class=io.debezium.connector.postgresql.PostgresConnector
-converters=st2str,vec2str
+converters=st2str,vec2str,arr2str
 st2str.type=com.risingwave.connector.cdc.debezium.converters.PgCompositeToStringConverter
 vec2str.type=com.risingwave.connector.cdc.debezium.converters.PgVectorToStringConverter
+arr2str.type=com.risingwave.connector.cdc.debezium.converters.PgArrayToStringConverter
 # default snapshot mode to initial
 snapshot.mode=${debezium.snapshot.mode:-initial}
 database.hostname=${hostname}

--- a/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgArrayToStringConverter.java
+++ b/java/connector-node/risingwave-source-cdc/src/main/java/com/risingwave/connector/cdc/debezium/converters/PgArrayToStringConverter.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 RisingWave Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.risingwave.connector.cdc.debezium.converters;
+
+import io.debezium.spi.converter.CustomConverter;
+import io.debezium.spi.converter.RelationalColumn;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.sql.Types;
+import java.util.Properties;
+import org.apache.kafka.connect.data.SchemaBuilder;
+
+/**
+ * Converts PostgreSQL array columns (e.g. _float4, _int4, _text[]) into plain strings.
+ *
+ * <p>Debezium's default handler for array columns uses an ARRAY schema. When an array column is
+ * unchanged and TOAST'd in an UPDATE, Debezium sends a bare {@code java.lang.Object} sentinel that
+ * cannot be placed into an ARRAY-typed schema slot, causing {@code Struct.put} to throw {@code
+ * DataException: Invalid Java object for schema with type ARRAY: class java.lang.Object}.
+ *
+ * <p>This converter bypasses that by registering an OPTIONAL STRING schema for all array columns
+ * ({@code jdbcType == Types.ARRAY}). Normal values are passed through as the Postgres text array
+ * representation (e.g. {@code {1.5,2.3}}), and the TOAST sentinel is converted to the canonical
+ * {@code __debezium_unavailable_value} string. The downstream RisingWave JSON parser handles both
+ * forms, and the TOAST replacement logic in the materialize executor takes over from there.
+ */
+public class PgArrayToStringConverter implements CustomConverter<SchemaBuilder, RelationalColumn> {
+
+    // Must match `DEBEZIUM_UNAVAILABLE_VALUE` on the Rust side (src/common/src/types/mod.rs).
+    // For ARRAY-schema columns, Debezium sends a bare `java.lang.Object` singleton as the TOAST
+    // sentinel (instead of the usual placeholder string, which would fail ARRAY schema validation).
+    // We translate that sentinel to the canonical string here.
+    private static final String UNAVAILABLE_VALUE_PLACEHOLDER = "__debezium_unavailable_value";
+
+    @Override
+    public void configure(Properties props) {}
+
+    @Override
+    public void converterFor(
+            RelationalColumn column, ConverterRegistration<SchemaBuilder> registration) {
+        if (column.jdbcType() == Types.ARRAY) {
+            registration.register(SchemaBuilder.string().optional(), this::convertArray);
+        }
+    }
+
+    private String convertArray(Object value) {
+        if (value == null) {
+            return null;
+        }
+        // For ARRAY-schema columns, Debezium's TOAST sentinel is a bare `java.lang.Object`
+        // singleton. Normal values arrive as concrete subclasses (String, byte[], etc.), so a
+        // value whose runtime class is exactly Object can only be the sentinel.
+        if (value.getClass() == Object.class) {
+            return UNAVAILABLE_VALUE_PLACEHOLDER;
+        }
+        if (value instanceof byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        if (value instanceof ByteBuffer buffer) {
+            var readOnly = buffer.asReadOnlyBuffer();
+            var bytes = new byte[readOnly.remaining()];
+            readOnly.get(bytes);
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+        return value.toString();
+    }
+}

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -122,6 +122,15 @@ pub static DEBEZIUM_UNAVAILABLE_JSON: std::sync::LazyLock<JsonbVal> =
 /// having all elements simultaneously equal to `f32::MAX` is effectively impossible.
 pub const DEBEZIUM_UNAVAILABLE_VECTOR_ELEM: f32 = f32::MAX;
 
+/// Magic element values used to build the Debezium unchanged-TOAST sentinel for floating-point
+/// array columns (`real[]`, `double precision[]`). A string placeholder cannot be embedded in a
+/// numeric list, so we encode the sentinel as a single-element list holding this value. `f32::MAX`
+/// / `f64::MAX` are valid floats (so they pass `check_datum_type`) yet effectively never appear in
+/// real data, mirroring the pgvector sentinel. Integer arrays have no such impossible value, so
+/// they are not covered — use `REPLICA IDENTITY FULL` for full-fidelity TOAST on those columns.
+pub const DEBEZIUM_UNAVAILABLE_FLOAT32_ELEM: f32 = f32::MAX;
+pub const DEBEZIUM_UNAVAILABLE_FLOAT64_ELEM: f64 = f64::MAX;
+
 /// Build a sentinel `VectorVal` of the given dimension to represent Debezium's
 /// unchanged-TOAST placeholder. The dimension must match the column's declared
 /// `vector(N)` size so it passes `check_datum_type` on the way through the

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -22,6 +22,7 @@ use risingwave_common::array::{Finite32, ListValue, StructValue};
 use risingwave_common::cast::{i64_to_timestamp, i64_to_timestamptz, str_to_bytea};
 use risingwave_common::log::LogSuppressor;
 use risingwave_common::types::{
+    DEBEZIUM_UNAVAILABLE_FLOAT32_ELEM, DEBEZIUM_UNAVAILABLE_FLOAT64_ELEM, DEBEZIUM_UNAVAILABLE_JSON,
     DEBEZIUM_UNAVAILABLE_VALUE, DataType, Date, Decimal, Int256, Interval, JsonbVal, ScalarImpl,
     Time, Timestamp, Timestamptz, ToOwnedDatum, VectorVal, debezium_unavailable_vector,
 };
@@ -676,6 +677,42 @@ impl JsonParseOptions {
                 builder.finish()
             })
             .into(),
+            // ---- List from Postgres text array (via `PgArrayToStringConverter`) -----
+            // The converter registers an OPTIONAL STRING schema for all Postgres array columns,
+            // so values arrive here as the text array format "{1.5,2.3,NULL}" or, for an unchanged
+            // TOAST'd column, as the placeholder string.
+            (DataType::List(list_type), ValueType::String) => {
+                let s = value.as_str().unwrap();
+                if self.handle_toast_columns && s == DEBEZIUM_UNAVAILABLE_VALUE {
+                    // Emit a single-element sentinel list that `is_debezium_unavailable_value` in
+                    // the materialize cache detects and replaces with the previous value. Element
+                    // types that can carry the signal: string-compatible types hold the placeholder
+                    // string; floating-point types hold the magic `f32::MAX`/`f64::MAX` element
+                    // (mirroring the pgvector sentinel). Integer/decimal/temporal arrays have no
+                    // impossible value to reserve, so they fall back to null — use
+                    // `REPLICA IDENTITY FULL` for full-fidelity TOAST on those
+                    // (risingwavelabs/risingwave#22916).
+                    let sentinel = match list_type.elem() {
+                        DataType::Varchar => ScalarImpl::Utf8(DEBEZIUM_UNAVAILABLE_VALUE.into()),
+                        DataType::Jsonb => ScalarImpl::Jsonb(DEBEZIUM_UNAVAILABLE_JSON.clone()),
+                        DataType::Bytea => {
+                            ScalarImpl::Bytea(DEBEZIUM_UNAVAILABLE_VALUE.as_bytes().into())
+                        }
+                        DataType::Float32 => {
+                            ScalarImpl::Float32(DEBEZIUM_UNAVAILABLE_FLOAT32_ELEM.into())
+                        }
+                        DataType::Float64 => {
+                            ScalarImpl::Float64(DEBEZIUM_UNAVAILABLE_FLOAT64_ELEM.into())
+                        }
+                        _ => return Ok(DatumCow::NULL),
+                    };
+                    ListValue::from_datum_iter(list_type.elem(), [Some(sentinel)]).into()
+                } else {
+                    ListValue::from_str(s, type_expected)
+                        .map_err(|_| create_error())?
+                        .into()
+                }
+            }
             // ---- Vector -----
             (DataType::Vector(size), ValueType::Array) => {
                 let array = value.as_array().unwrap();

--- a/src/stream/src/executor/mview/cache.rs
+++ b/src/stream/src/executor/mview/cache.rs
@@ -450,7 +450,10 @@ fn versions_are_newer_or_equal(
 /// TOAST column handling for CDC tables with TOAST columns.
 mod toast {
     use risingwave_common::row::Row as _;
-    use risingwave_common::types::{DEBEZIUM_UNAVAILABLE_VALUE, DEBEZIUM_UNAVAILABLE_VECTOR_ELEM};
+    use risingwave_common::types::{
+        DEBEZIUM_UNAVAILABLE_FLOAT32_ELEM, DEBEZIUM_UNAVAILABLE_FLOAT64_ELEM,
+        DEBEZIUM_UNAVAILABLE_VALUE, DEBEZIUM_UNAVAILABLE_VECTOR_ELEM,
+    };
 
     use super::*;
 
@@ -498,6 +501,16 @@ mod toast {
                     && slice
                         .iter()
                         .all(|f| f.0 == DEBEZIUM_UNAVAILABLE_VECTOR_ELEM)
+            }
+            Some(risingwave_common::types::ScalarRefImpl::Float32(val)) => {
+                // Floating-point array TOAST sentinel: the JSON parser materialises a
+                // single-element list holding `f32::MAX` for an unchanged-TOAST `real[]`.
+                // A real `real[]` containing exactly `f32::MAX` is effectively impossible.
+                val.0 == DEBEZIUM_UNAVAILABLE_FLOAT32_ELEM
+            }
+            Some(risingwave_common::types::ScalarRefImpl::Float64(val)) => {
+                // Same as above for `double precision[]` (`f64::MAX`).
+                val.0 == DEBEZIUM_UNAVAILABLE_FLOAT64_ELEM
             }
             Some(risingwave_common::types::ScalarRefImpl::List(list_ref)) => {
                 // For list type, check if it contains exactly one element with the unavailable value

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -256,8 +256,11 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                     // - varchar (DataType::Varchar)
                     // - bytea (DataType::Bytea)
                     // - pgvector (DataType::Vector)
-                    // - One-dimensional arrays of the above types (DataType::List)
-                    //   Note: Some array types may not be fully supported yet, see issue  https://github.com/risingwavelabs/risingwave/issues/22916 for details.
+                    // - One-dimensional arrays of the above types, plus real[]/double precision[]
+                    //   (DataType::List). Integer/decimal/temporal arrays have no impossible
+                    //   sentinel value and fall back to null under REPLICA IDENTITY DEFAULT; use
+                    //   REPLICA IDENTITY FULL for full-fidelity TOAST on those. See issue
+                    //   https://github.com/risingwavelabs/risingwave/issues/22916 for details.
 
                     // For details on how TOAST values are handled, see comments in `is_debezium_unavailable_value`.
                     DataType::Varchar


### PR DESCRIPTION
## What this PR does

Makes Postgres array columns work correctly over CDC, and stops unchanged large (TOAST'd) array columns from being lost when an unrelated column is updated.

Before this change, replicating a Postgres table with array columns could crash the CDC pipeline outright, and even when it didn't, an update to any non-array column could silently wipe out a large array value on the RisingWave side.

## Why this was needed

Postgres stores large column values out-of-line using a mechanism called TOAST. Under the default replication setting (`REPLICA IDENTITY DEFAULT`), when you update a row, Postgres does **not** re-send any large column you didn't actually change — it leaves a "unchanged" marker instead, to save space.

For normal columns this is handled fine. But for **array** columns, the marker doesn't fit the expected array shape, which:

1. **Crashed the connector** with `Invalid Java object for schema with type ARRAY`, and
2. when it didn't crash, left RisingWave unable to tell "this array is unchanged" apart from "this array is now empty/null" — so the original value was lost.

This PR closes both gaps: arrays ingest cleanly, and an unchanged TOAST'd array is recognized and **restored from the value RisingWave already has stored**, instead of being dropped.

## How it works (overview flow)

When an UPDATE arrives that touches a non-array column but leaves a large array untouched, the data flows like this:

1. **Postgres** omits the unchanged array from the change log (TOAST optimization).
2. **CDC layer** detects the omission and replaces it with a special "unchanged" marker.
3. **RisingWave parser** recognizes that marker and tags the array with an internal sentinel value — a value that real data effectively never contains.
4. **RisingWave's materialize step** sees the sentinel, understands "this array didn't actually change," and refills it with the previously stored value for that row.
5. The final row has the new column edit applied **and** the original array intact.

The net effect: editing one column of a row never destroys the other large columns, which is what users expect.

## Scope and a known limitation

This recovery works for text, JSON, bytes, **and** floating-point arrays (`real[]`, `double precision[]`).

It does **not** cover integer / numeric / date-time arrays. The recovery relies on reserving an "impossible" value as the internal signal — floating-point types have one (an extreme value real data never uses), but integers do not (every integer is a value some application might legitimately store, so there's no safe value to reserve).

For those array types, the recommended fix is on the Postgres side: set `REPLICA IDENTITY FULL` on the table. Postgres then always sends the real value of every column, so there's nothing to reconstruct and **all** array types are preserved with no special handling. See `risingwavelabs/risingwave#22916`.

## Demonstration

Table with a large array column:

```sql
CREATE TABLE readings (
  id      int PRIMARY KEY,
  label   text,
  samples real[]      -- ~5000 floats, large enough to be TOAST'd
);
-- existing row: id=1, label='old', samples={0.11, 0.22, ... 5000 values ...}
```

RisingWave has already replicated that full row. Now someone updates an unrelated column:

```sql
UPDATE readings SET label = 'new' WHERE id = 1;   -- samples is NOT touched
```

Step by step:

| Hop                                | `REPLICA IDENTITY DEFAULT`                       | `REPLICA IDENTITY FULL`                         |
| ---------------------------------- | ------------------------------------------------ | ----------------------------------------------- |
| Postgres change log                | `samples` omitted (unchanged + large)            | `samples = {0.11, 0.22, ...}` (real value sent) |
| CDC layer                          | substitutes the "unchanged" marker               | sends the actual array text                     |
| RisingWave parser (float arrays)   | tags array with internal sentinel                | parses the array normally                       |
| RisingWave materialize             | detects sentinel → restores old value from state | nothing special to do                           |
| **Final result (float arrays)**    | **original array preserved ✅**                  | **original array preserved ✅**                 |
| RisingWave parser (integer arrays) | becomes `NULL` ✗ (no safe sentinel)              | parses normally ✅ (no recovery needed)         |

**Result with the fix:**

```
id=1,  label='new',  samples={0.11, 0.22, ... original 5000 values ...}
```

The label edit is applied, and the untouched 5000-element array is fully preserved instead of being lost.

## Testing

Verified locally against a Postgres CDC source with a table containing scalar TOAST columns plus `text[]`, `jsonb[]`, `bytea[]`, `real[]`, and `double precision[]`:

- Under `REPLICA IDENTITY DEFAULT`, updating a non-array column preserves all eligible array columns — including the float arrays — with no marker or sentinel leaking into the result.
- Under `REPLICA IDENTITY FULL`, all array types (including integer arrays) are preserved.