### PR TITLE
fix(connector/spanner-cdc): embed Debezium source metadata in CDC payload for metadata column resolution

### DIFF
--- a/src/connector/src/source/spanner_cdc/source/message.rs
+++ b/src/connector/src/source/spanner_cdc/source/message.rs
@@ -24,6 +24,7 @@ use crate::source::{SplitId};
 #[derive(Debug, Clone)]
 pub struct TaggedChangeRecord {
     pub split_id: SplitId,
+    pub database_name: String,
     pub data_change: DataChangeRecord,
     pub modification: Mod,
 }
@@ -34,22 +35,34 @@ impl From<TaggedChangeRecord> for SourceMessage {
         // The offset will be set by the reader to include full partition state
         // Default to the commit timestamp nanos
         let offset = commit_timestamp.unix_timestamp_nanos().to_string();
-        // Wrap in a Debezium-compatible envelope: {"payload": {"before":..,"after":..,"op":..}}
+        let source_ts_ms = (commit_timestamp.unix_timestamp_nanos() / 1_000_000) as i64;
+        // Wrap in a Debezium-compatible envelope: {"payload": {"before":..,"after":..,"op":..,"source":..}}
         // The shared CDC source schema has a `payload` JSONB column; the parser extracts
         // the top-level "payload" field.  Without this wrapper the field is missing and the
         // column is padded with NULL, which causes the backfill executor to panic.
+        // The `source` sub-object mirrors the Debezium source envelope so that INCLUDE TIMESTAMP,
+        // INCLUDE database_name, and INCLUDE table_name columns resolve correctly when
+        // parse_debezium_chunk re-parses the stored payload without row_meta.
         let mod_json = record
             .modification
             .to_json_map(&record.data_change.mod_type, &record.data_change)
-            .and_then(|inner| {
+            .and_then(|mut inner| {
+                let mut source = serde_json::Map::new();
+                source.insert("ts_ms".to_string(), serde_json::Value::from(source_ts_ms));
+                source.insert(
+                    "db".to_string(),
+                    serde_json::Value::String(record.database_name.clone()),
+                );
+                source.insert(
+                    "table".to_string(),
+                    serde_json::Value::String(record.data_change.table_name.clone()),
+                );
+                inner.insert("source".to_string(), serde_json::Value::Object(source));
                 let mut envelope = serde_json::Map::new();
                 envelope.insert("payload".to_string(), serde_json::Value::Object(inner));
                 serde_json::to_vec(&envelope).map_err(Into::into)
             })
             .expect("Spanner change record serialization to JSON should never fail");
-
-        let source_ts_ms =
-            (commit_timestamp.unix_timestamp_nanos() / 1_000_000) as i64;
 
         SourceMessage {
             key: None,

--- a/src/connector/src/source/spanner_cdc/source/reader.rs
+++ b/src/connector/src/source/spanner_cdc/source/reader.rs
@@ -107,6 +107,7 @@ impl SplitReader for SpannerCdcSplitReader {
 
         let ctx = ReaderContext {
             client,
+            database: properties.database.clone(),
             change_stream_name: properties.change_stream_name.clone(),
             heartbeat_interval_ms,
             retry_attempts: properties.get_retry_attempts(),
@@ -170,6 +171,7 @@ impl SpannerCdcSplitReader {
 
 struct ReaderContext {
     client: Client,
+    database: String,
     change_stream_name: String,
     heartbeat_interval_ms: i64,
     retry_attempts: u32,
@@ -578,6 +580,7 @@ fn spawn_partition_task(
     child_discovery_tx: tokio::sync::mpsc::UnboundedSender<SpannerCdcSplit>,
 ) {
     let client = ctx.client.clone();
+    let database = ctx.database.clone();
     let change_stream_name = ctx.change_stream_name.clone();
     let heartbeat_interval_ms = ctx.heartbeat_interval_ms;
     let retry_attempts = ctx.retry_attempts;
@@ -593,6 +596,7 @@ fn spawn_partition_task(
     partition_streams.push(tokio::spawn(async move {
         read_partition(
             client,
+            database,
             split,
             change_stream_name,
             heartbeat_interval_ms,
@@ -617,6 +621,7 @@ fn spawn_partition_task(
 
 async fn read_partition(
     client: Client,
+    database: String,
     mut split: SpannerCdcSplit,
     change_stream_name: String,
     heartbeat_interval_ms: i64,
@@ -659,6 +664,7 @@ async fn read_partition(
             &stmt,
             &mut split,
             &split_id,
+            &database,
             &offsets,
             &shared_schema,
             &tx,
@@ -686,6 +692,7 @@ async fn read_partition(
             &stmt,
             &mut split,
             &split_id,
+            &database,
             &offsets,
             &shared_schema,
             &tx,
@@ -723,6 +730,7 @@ async fn execute_query(
     stmt: &Statement,
     split: &mut SpannerCdcSplit,
     split_id: &SplitId,
+    database: &str,
     offsets: &PartitionOffsets,
     shared_schema: &std::sync::Mutex<SchemaTracker>,
     tx: &mpsc::Sender<Vec<SourceMessage>>,
@@ -799,6 +807,7 @@ async fn execute_query(
                 for modification in &data_change.mods {
                     let tagged = TaggedChangeRecord {
                         split_id: split_id.clone(),
+                        database_name: database.to_owned(),
                         data_change: data_change.clone(),
                         modification: modification.clone(),
                     };


### PR DESCRIPTION
## Problem

Spanner CDC tables using `INCLUDE TIMESTAMP`, `INCLUDE database_name`, or `INCLUDE table_name` were silently receiving `NULL` for every CDC row during streaming.

The `StreamCdcScan` executor re-parses stored CDC payloads during CDC replay without access to the original source metadata. When this happens, the parser falls back to resolving metadata columns directly from the Debezium payload JSON — reading fields such as `payload.source.ts_ms`, `payload.source.db`, and `payload.source.table`. Spanner CDC payloads had no `source` field at all, so every metadata column fell through to `NULL` with a suppressed warning on every message.

For tables using `INCLUDE TIMESTAMP` as a watermark source, this caused the watermark to never advance and TTL-based cleanup to stall indefinitely. For tables using `INCLUDE database_name` or `INCLUDE table_name`, those columns were always empty.

## Fix

Embed a Debezium-compatible `source` sub-object into the Spanner CDC payload at message construction time, carrying `ts_ms`, `db`, and `table`. This makes Spanner CDC payloads self-contained — metadata columns resolve correctly regardless of whether a message is processed via the live streaming path (which has source metadata in memory) or re-parsed from storage (which does not).

The database name, previously not propagated below the top-level reader configuration, is now threaded through the reader pipeline so it is available at the point each message is constructed.

## Impact

- `INCLUDE TIMESTAMP`, `INCLUDE database_name`, and `INCLUDE table_name` columns now resolve correctly for all Spanner CDC tables
- No behaviour change for the live streaming path