### PR TITLE
fix(meta): make WAIT TABLE block until CDC snapshot backfill completes

### DIFF
--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -25,9 +25,9 @@ use percent_encoding::percent_decode_str;
 use pgwire::pg_response::{PgResponse, StatementType};
 use prost::Message as _;
 use risingwave_common::catalog::{
-    CdcTableDesc, ColumnCatalog, ColumnDesc, ConflictBehavior, DEFAULT_SCHEMA_NAME, Engine,
-    ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX, RISINGWAVE_ICEBERG_ROW_ID, ROW_ID_COLUMN_NAME,
-    TableId, ObjectId,
+    CdcTableDesc, ColumnCatalog, ColumnDesc, ConflictBehavior, CreateType, DEFAULT_SCHEMA_NAME,
+    Engine, ICEBERG_SINK_PREFIX, ICEBERG_SOURCE_PREFIX, RISINGWAVE_ICEBERG_ROW_ID,
+    ROW_ID_COLUMN_NAME, TableId, ObjectId,
 };
 use risingwave_common::config::MetaBackend;
 use risingwave_common::global_jvm::Jvm;
@@ -819,8 +819,15 @@ fn gen_table_plan_inner(
         }
     }
 
-    let materialize =
-        plan_root.gen_table_plan(context, table_name, database_id, schema_id, info, props)?;
+    let materialize = plan_root.gen_table_plan(
+        context,
+        table_name,
+        database_id,
+        schema_id,
+        info,
+        props,
+        CreateType::Foreground,
+    )?;
 
     let mut table = materialize.table().clone();
     table.owner = session.user_id();
@@ -956,6 +963,11 @@ pub(crate) fn gen_create_table_plan_for_cdc_table(
         external_table_name
     };
     let cdc_table_id = build_cdc_table_id(source.id, &cdc_table_id_external_table_name);
+    let create_type = if session.config().background_ddl() {
+        CreateType::Background
+    } else {
+        CreateType::Foreground
+    };
     let materialize = plan_root.gen_table_plan(
         context,
         resolved_table_name,
@@ -977,6 +989,7 @@ pub(crate) fn gen_create_table_plan_for_cdc_table(
             webhook_info: None,
             engine,
         },
+        create_type,
     )?;
 
     let mut table = materialize.table().clone();

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -56,7 +56,7 @@ pub use optimizer_context::*;
 use plan_expr_rewriter::ConstEvalRewriter;
 use property::Order;
 use risingwave_common::bail;
-use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, ConflictBehavior, Field, Schema};
+use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, ConflictBehavior, CreateType, Field, Schema};
 use risingwave_common::types::DataType;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::iter_util::ZipEqDebug;
@@ -792,6 +792,7 @@ impl LogicalPlanRoot {
             webhook_info,
             engine,
         }: CreateTableProps,
+        create_type: CreateType,
     ) -> Result<StreamMaterialize> {
         let backfill_type = self.derive_backfill_type(false);
         // Snapshot backfill is not allowed for create table
@@ -1073,6 +1074,7 @@ impl LogicalPlanRoot {
             webhook_info,
             engine,
             refreshable,
+            create_type,
         )
     }
 

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -198,6 +198,7 @@ impl StreamMaterialize {
         webhook_info: Option<PbWebhookSourceInfo>,
         engine: Engine,
         refreshable: bool,
+        create_type: CreateType,
     ) -> Result<Self> {
         let input = Self::rewrite_input(input, user_distributed_by.clone(), TableType::Table)?;
 
@@ -219,7 +220,7 @@ impl StreamMaterialize {
             Some(version),
             Cardinality::unknown(), // unknown cardinality for tables
             retention_seconds,
-            CreateType::Foreground,
+            create_type,
             webhook_info,
             engine,
             refreshable,

--- a/src/meta/src/barrier/cdc_progress.rs
+++ b/src/meta/src/barrier/cdc_progress.rs
@@ -324,6 +324,56 @@ mod test {
         assert!(tracker.take_pre_completed());
     }
 
+    #[tokio::test]
+    async fn test_is_pre_completed() {
+        let split_count = 2u64;
+        let mut tracker = CdcTableBackfillTracker::new(
+            1.into(),
+            (0..split_count)
+                .map(|split_id| CdcTableSnapshotSplitRaw {
+                    split_id: split_id as _,
+                    left_bound_inclusive: vec![],
+                    right_bound_exclusive: vec![],
+                })
+                .collect(),
+        );
+        tracker
+            .reassign_splits([1.into()].into_iter().collect())
+            .unwrap();
+        let generation = tracker.progress().split_assignment_generation;
+
+        assert!(!tracker.is_pre_completed());
+        assert!(!tracker.take_pre_completed());
+
+        tracker.update_split_progress(&CdcTableBackfillProgress {
+            done: true,
+            split_id_start_inclusive: 0,
+            split_id_end_inclusive: 0,
+            generation,
+            fragment_id: 1.into(),
+            ..Default::default()
+        });
+        assert!(!tracker.is_pre_completed());
+
+        tracker.update_split_progress(&CdcTableBackfillProgress {
+            done: true,
+            split_id_start_inclusive: 1,
+            split_id_end_inclusive: 1,
+            generation,
+            fragment_id: 1.into(),
+            ..Default::default()
+        });
+        // All splits done: PreCompleted
+        assert!(tracker.is_pre_completed());
+        // Non-consuming: still PreCompleted
+        assert!(tracker.is_pre_completed());
+
+        // take_pre_completed transitions to Completed
+        assert!(tracker.take_pre_completed());
+        assert!(!tracker.is_pre_completed());
+        assert!(!tracker.take_pre_completed());
+    }
+
     fn assert_init_state(tracker: &CdcTableBackfillTracker, split_count: u64) {
         let CdcBackfillStatus::Backfilling(progress) = &tracker.status else {
             unreachable!()

--- a/src/meta/src/barrier/cdc_progress.rs
+++ b/src/meta/src/barrier/cdc_progress.rs
@@ -195,6 +195,10 @@ impl CdcTableBackfillTracker {
         }
     }
 
+    pub fn is_pre_completed(&self) -> bool {
+        matches!(self.status, CdcBackfillStatus::PreCompleted)
+    }
+
     pub fn take_pre_completed(&mut self) -> bool {
         if let CdcBackfillStatus::PreCompleted = &self.status {
             self.status = CdcBackfillStatus::Completed;

--- a/src/meta/src/barrier/cdc_progress.rs
+++ b/src/meta/src/barrier/cdc_progress.rs
@@ -324,56 +324,6 @@ mod test {
         assert!(tracker.take_pre_completed());
     }
 
-    #[tokio::test]
-    async fn test_is_pre_completed() {
-        let split_count = 2u64;
-        let mut tracker = CdcTableBackfillTracker::new(
-            1.into(),
-            (0..split_count)
-                .map(|split_id| CdcTableSnapshotSplitRaw {
-                    split_id: split_id as _,
-                    left_bound_inclusive: vec![],
-                    right_bound_exclusive: vec![],
-                })
-                .collect(),
-        );
-        tracker
-            .reassign_splits([1.into()].into_iter().collect())
-            .unwrap();
-        let generation = tracker.progress().split_assignment_generation;
-
-        assert!(!tracker.is_pre_completed());
-        assert!(!tracker.take_pre_completed());
-
-        tracker.update_split_progress(&CdcTableBackfillProgress {
-            done: true,
-            split_id_start_inclusive: 0,
-            split_id_end_inclusive: 0,
-            generation,
-            fragment_id: 1.into(),
-            ..Default::default()
-        });
-        assert!(!tracker.is_pre_completed());
-
-        tracker.update_split_progress(&CdcTableBackfillProgress {
-            done: true,
-            split_id_start_inclusive: 1,
-            split_id_end_inclusive: 1,
-            generation,
-            fragment_id: 1.into(),
-            ..Default::default()
-        });
-        // All splits done: PreCompleted
-        assert!(tracker.is_pre_completed());
-        // Non-consuming: still PreCompleted
-        assert!(tracker.is_pre_completed());
-
-        // take_pre_completed transitions to Completed
-        assert!(tracker.take_pre_completed());
-        assert!(!tracker.is_pre_completed());
-        assert!(!tracker.take_pre_completed());
-    }
-
     fn assert_init_state(tracker: &CdcTableBackfillTracker, split_count: u64) {
         let CdcBackfillStatus::Backfilling(progress) = &tracker.status else {
             unreachable!()

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -768,11 +768,11 @@ impl InflightDatabaseInfo {
                 let (is_finished, truncate_table_ids) = tracker.collect_staging_commit_info();
                 table_ids_to_truncate.extend(truncate_table_ids);
                 if is_finished {
-                    let cdc_not_done = job
+                    let cdc_backfill_not_done = job
                         .cdc_table_backfill_tracker
                         .as_ref()
                         .is_some_and(|t| !t.is_pre_completed());
-                    if !cdc_not_done {
+                    if !cdc_backfill_not_done {
                         let CreateStreamingJobStatus::Creating { tracker, .. } =
                             replace(&mut job.status, CreateStreamingJobStatus::Created)
                         else {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -739,12 +739,20 @@ impl InflightDatabaseInfo {
     fn iter_mut_creating_job_tracker(
         &mut self,
     ) -> impl Iterator<Item = &mut CreateMviewProgressTracker> {
-        self.jobs
-            .values_mut()
-            .filter_map(|job| match &mut job.status {
-                CreateStreamingJobStatus::Creating { tracker, .. } => Some(tracker),
-                _ => None,
-            })
+        self.jobs.values_mut().filter_map(|job| {
+            let CreateStreamingJobStatus::Creating { tracker } = &mut job.status else {
+                return None;
+            };
+            if tracker.is_finished()
+                && job
+                    .cdc_table_backfill_tracker
+                    .as_ref()
+                    .is_some_and(|t| !t.is_pre_completed())
+            {
+                return None;
+            }
+            Some(tracker)
+        })
     }
 
     pub(super) fn has_pending_finished_jobs(&self) -> bool {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -739,20 +739,12 @@ impl InflightDatabaseInfo {
     fn iter_mut_creating_job_tracker(
         &mut self,
     ) -> impl Iterator<Item = &mut CreateMviewProgressTracker> {
-        self.jobs.values_mut().filter_map(|job| {
-            let CreateStreamingJobStatus::Creating { tracker } = &mut job.status else {
-                return None;
-            };
-            if tracker.is_finished()
-                && job
-                    .cdc_table_backfill_tracker
-                    .as_ref()
-                    .is_some_and(|t| !t.is_pre_completed())
-            {
-                return None;
-            }
-            Some(tracker)
-        })
+        self.jobs
+            .values_mut()
+            .filter_map(|job| match &mut job.status {
+                CreateStreamingJobStatus::Creating { tracker, .. } => Some(tracker),
+                _ => None,
+            })
     }
 
     pub(super) fn has_pending_finished_jobs(&self) -> bool {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -793,16 +793,12 @@ impl InflightDatabaseInfo {
                 && cdc_backfill_tracker.take_pre_completed()
             {
                 finished_cdc_table_backfill.push(*job_id);
-                if let CreateStreamingJobStatus::Creating { tracker } = &job.status
-                    && tracker.is_finished()
-                {
-                    let CreateStreamingJobStatus::Creating { tracker } =
-                        replace(&mut job.status, CreateStreamingJobStatus::Created)
-                    else {
-                        unreachable!()
-                    };
-                    finished_jobs.push(tracker.into_tracking_job());
-                }
+                let CreateStreamingJobStatus::Creating { tracker } =
+                    replace(&mut job.status, CreateStreamingJobStatus::Created)
+                else {
+                    unreachable!()
+                };
+                finished_jobs.push(tracker.into_tracking_job());
             }
         }
         StagingCommitInfo {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -48,7 +48,7 @@ use crate::barrier::command::{
 use crate::barrier::edge_builder::{
     EdgeBuilderFragmentInfo, FragmentEdgeBuildResult, FragmentEdgeBuilder,
 };
-use crate::barrier::progress::{CreateMviewProgressTracker, StagingCommitInfo, TrackingJob};
+use crate::barrier::progress::{CreateMviewProgressTracker, StagingCommitInfo};
 use crate::barrier::rpc::{ControlStreamManager, to_partial_graph_id};
 use crate::barrier::{
     BackfillProgress, BarrierKind, CreateStreamingJobType, FragmentBackfillProgress, TracedEpoch,
@@ -397,7 +397,6 @@ pub enum SubscriberType {
 pub(super) enum CreateStreamingJobStatus {
     Init,
     Creating { tracker: CreateMviewProgressTracker },
-    CdcBackfilling { tracking_job: TrackingJob },
     Created,
 }
 
@@ -537,7 +536,6 @@ impl InflightDatabaseInfo {
                         },
                     ))
                 }
-                CreateStreamingJobStatus::CdcBackfilling { .. } => None,
                 CreateStreamingJobStatus::Created => None,
             })
     }
@@ -670,7 +668,7 @@ impl InflightDatabaseInfo {
                     continue;
                 }
                 CreateStreamingJobStatus::Creating { tracker, .. } => tracker,
-                CreateStreamingJobStatus::CdcBackfilling { .. } | CreateStreamingJobStatus::Created => {
+                CreateStreamingJobStatus::Created => {
                     if !progress.done {
                         warn!("update the progress of an created streaming job: {progress:?}");
                     }
@@ -725,7 +723,6 @@ impl InflightDatabaseInfo {
         self.jobs.values().filter_map(|job| match &job.status {
             CreateStreamingJobStatus::Init => None,
             CreateStreamingJobStatus::Creating { tracker, .. } => Some(tracker),
-            CreateStreamingJobStatus::CdcBackfilling { .. } => None,
             CreateStreamingJobStatus::Created => None,
         })
     }
@@ -738,14 +735,22 @@ impl InflightDatabaseInfo {
             .filter_map(|job| match &mut job.status {
                 CreateStreamingJobStatus::Init => None,
                 CreateStreamingJobStatus::Creating { tracker, .. } => Some(tracker),
-                CreateStreamingJobStatus::CdcBackfilling { .. } => None,
                 CreateStreamingJobStatus::Created => None,
             })
     }
 
     pub(super) fn has_pending_finished_jobs(&self) -> bool {
-        self.iter_creating_job_tracker()
-            .any(|tracker| tracker.is_finished())
+        self.jobs.values().any(|job| {
+            let CreateStreamingJobStatus::Creating { tracker } = &job.status else {
+                return false;
+            };
+            if !tracker.is_finished() {
+                return false;
+            }
+            !job.cdc_table_backfill_tracker
+                .as_ref()
+                .is_some_and(|t| !t.is_pre_completed())
+        })
     }
 
     pub(super) fn take_pending_backfill_nodes(&mut self) -> Vec<FragmentId> {
@@ -766,30 +771,30 @@ impl InflightDatabaseInfo {
                     let cdc_not_done = job
                         .cdc_table_backfill_tracker
                         .as_ref()
-                        .map(|t| !t.is_pre_completed())
-                        .unwrap_or(false);
-                    let CreateStreamingJobStatus::Creating { tracker, .. } =
-                        replace(&mut job.status, CreateStreamingJobStatus::Created)
-                    else {
-                        unreachable!()
-                    };
-                    if cdc_not_done {
-                        job.status = CreateStreamingJobStatus::CdcBackfilling {
-                            tracking_job: tracker.into_tracking_job(),
+                        .is_some_and(|t| !t.is_pre_completed());
+                    if !cdc_not_done {
+                        let CreateStreamingJobStatus::Creating { tracker, .. } =
+                            replace(&mut job.status, CreateStreamingJobStatus::Created)
+                        else {
+                            unreachable!()
                         };
-                    } else {
                         finished_jobs.push(tracker.into_tracking_job());
                     }
                 }
             }
-            if let Some(tracker) = &mut job.cdc_table_backfill_tracker
-                && tracker.take_pre_completed()
+            if let Some(cdc_tracker) = &mut job.cdc_table_backfill_tracker
+                && cdc_tracker.take_pre_completed()
             {
                 finished_cdc_table_backfill.push(*job_id);
-                if let CreateStreamingJobStatus::CdcBackfilling { tracking_job } =
-                    replace(&mut job.status, CreateStreamingJobStatus::Created)
+                if let CreateStreamingJobStatus::Creating { tracker } = &job.status
+                    && tracker.is_finished()
                 {
-                    finished_jobs.push(tracking_job);
+                    let CreateStreamingJobStatus::Creating { tracker } =
+                        replace(&mut job.status, CreateStreamingJobStatus::Created)
+                    else {
+                        unreachable!()
+                    };
+                    finished_jobs.push(tracker.into_tracking_job());
                 }
             }
         }

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -793,12 +793,6 @@ impl InflightDatabaseInfo {
                 && cdc_backfill_tracker.take_pre_completed()
             {
                 finished_cdc_table_backfill.push(*job_id);
-                let CreateStreamingJobStatus::Creating { tracker } =
-                    replace(&mut job.status, CreateStreamingJobStatus::Created)
-                else {
-                    unreachable!()
-                };
-                finished_jobs.push(tracker.into_tracking_job());
             }
         }
         StagingCommitInfo {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -48,7 +48,7 @@ use crate::barrier::command::{
 use crate::barrier::edge_builder::{
     EdgeBuilderFragmentInfo, FragmentEdgeBuildResult, FragmentEdgeBuilder,
 };
-use crate::barrier::progress::{CreateMviewProgressTracker, StagingCommitInfo};
+use crate::barrier::progress::{CreateMviewProgressTracker, StagingCommitInfo, TrackingJob};
 use crate::barrier::rpc::{ControlStreamManager, to_partial_graph_id};
 use crate::barrier::{
     BackfillProgress, BarrierKind, CreateStreamingJobType, FragmentBackfillProgress, TracedEpoch,
@@ -397,6 +397,7 @@ pub enum SubscriberType {
 pub(super) enum CreateStreamingJobStatus {
     Init,
     Creating { tracker: CreateMviewProgressTracker },
+    CdcBackfilling { tracking_job: TrackingJob },
     Created,
 }
 
@@ -536,6 +537,7 @@ impl InflightDatabaseInfo {
                         },
                     ))
                 }
+                CreateStreamingJobStatus::CdcBackfilling { .. } => None,
                 CreateStreamingJobStatus::Created => None,
             })
     }
@@ -668,7 +670,7 @@ impl InflightDatabaseInfo {
                     continue;
                 }
                 CreateStreamingJobStatus::Creating { tracker, .. } => tracker,
-                CreateStreamingJobStatus::Created => {
+                CreateStreamingJobStatus::CdcBackfilling { .. } | CreateStreamingJobStatus::Created => {
                     if !progress.done {
                         warn!("update the progress of an created streaming job: {progress:?}");
                     }
@@ -723,6 +725,7 @@ impl InflightDatabaseInfo {
         self.jobs.values().filter_map(|job| match &job.status {
             CreateStreamingJobStatus::Init => None,
             CreateStreamingJobStatus::Creating { tracker, .. } => Some(tracker),
+            CreateStreamingJobStatus::CdcBackfilling { .. } => None,
             CreateStreamingJobStatus::Created => None,
         })
     }
@@ -735,6 +738,7 @@ impl InflightDatabaseInfo {
             .filter_map(|job| match &mut job.status {
                 CreateStreamingJobStatus::Init => None,
                 CreateStreamingJobStatus::Creating { tracker, .. } => Some(tracker),
+                CreateStreamingJobStatus::CdcBackfilling { .. } => None,
                 CreateStreamingJobStatus::Created => None,
             })
     }
@@ -759,18 +763,34 @@ impl InflightDatabaseInfo {
                 let (is_finished, truncate_table_ids) = tracker.collect_staging_commit_info();
                 table_ids_to_truncate.extend(truncate_table_ids);
                 if is_finished {
+                    let cdc_not_done = job
+                        .cdc_table_backfill_tracker
+                        .as_ref()
+                        .map(|t| !t.is_pre_completed())
+                        .unwrap_or(false);
                     let CreateStreamingJobStatus::Creating { tracker, .. } =
                         replace(&mut job.status, CreateStreamingJobStatus::Created)
                     else {
                         unreachable!()
                     };
-                    finished_jobs.push(tracker.into_tracking_job());
+                    if cdc_not_done {
+                        job.status = CreateStreamingJobStatus::CdcBackfilling {
+                            tracking_job: tracker.into_tracking_job(),
+                        };
+                    } else {
+                        finished_jobs.push(tracker.into_tracking_job());
+                    }
                 }
             }
             if let Some(tracker) = &mut job.cdc_table_backfill_tracker
                 && tracker.take_pre_completed()
             {
                 finished_cdc_table_backfill.push(*job_id);
+                if let CreateStreamingJobStatus::CdcBackfilling { tracking_job } =
+                    replace(&mut job.status, CreateStreamingJobStatus::Created)
+                {
+                    finished_jobs.push(tracking_job);
+                }
             }
         }
         StagingCommitInfo {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -782,8 +782,8 @@ impl InflightDatabaseInfo {
                     }
                 }
             }
-            if let Some(cdc_tracker) = &mut job.cdc_table_backfill_tracker
-                && cdc_tracker.take_pre_completed()
+            if let Some(cdc_backfill_tracker) = &mut job.cdc_table_backfill_tracker
+                && cdc_backfill_tracker.take_pre_completed()
             {
                 finished_cdc_table_backfill.push(*job_id);
                 if let CreateStreamingJobStatus::Creating { tracker } = &job.status

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -789,8 +789,8 @@ impl InflightDatabaseInfo {
                     }
                 }
             }
-            if let Some(cdc_backfill_tracker) = &mut job.cdc_table_backfill_tracker
-                && cdc_backfill_tracker.take_pre_completed()
+            if let Some(tracker) = &mut job.cdc_table_backfill_tracker
+                && tracker.take_pre_completed()
             {
                 finished_cdc_table_backfill.push(*job_id);
             }

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -740,18 +740,18 @@ impl InflightDatabaseInfo {
         &mut self,
     ) -> impl Iterator<Item = &mut CreateMviewProgressTracker> {
         self.jobs.values_mut().filter_map(|job| {
-            let cdc_backfill_pending = job
-                .cdc_table_backfill_tracker
-                .as_ref()
-                .is_some_and(|t| !t.is_pre_completed());
-            match &mut job.status {
-                CreateStreamingJobStatus::Creating { tracker }
-                    if !(tracker.is_finished() && cdc_backfill_pending) =>
-                {
-                    Some(tracker)
-                }
-                _ => None,
+            let CreateStreamingJobStatus::Creating { tracker } = &mut job.status else {
+                return None;
+            };
+            if tracker.is_finished()
+                && job
+                    .cdc_table_backfill_tracker
+                    .as_ref()
+                    .is_some_and(|t| !t.is_pre_completed())
+            {
+                return None;
             }
+            Some(tracker)
         })
     }
 
@@ -775,11 +775,11 @@ impl InflightDatabaseInfo {
                 let (is_finished, truncate_table_ids) = tracker.collect_staging_commit_info();
                 table_ids_to_truncate.extend(truncate_table_ids);
                 if is_finished {
-                    let cdc_backfill_not_done = job
+                    let cdc_backfill_pending = job
                         .cdc_table_backfill_tracker
                         .as_ref()
                         .is_some_and(|t| !t.is_pre_completed());
-                    if !cdc_backfill_not_done {
+                    if !cdc_backfill_pending {
                         let CreateStreamingJobStatus::Creating { tracker, .. } =
                             replace(&mut job.status, CreateStreamingJobStatus::Created)
                         else {

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -720,37 +720,44 @@ impl InflightDatabaseInfo {
     }
 
     fn iter_creating_job_tracker(&self) -> impl Iterator<Item = &CreateMviewProgressTracker> {
-        self.jobs.values().filter_map(|job| match &job.status {
-            CreateStreamingJobStatus::Init => None,
-            CreateStreamingJobStatus::Creating { tracker, .. } => Some(tracker),
-            CreateStreamingJobStatus::Created => None,
+        self.jobs.values().filter_map(|job| {
+            let CreateStreamingJobStatus::Creating { tracker } = &job.status else {
+                return None;
+            };
+            if tracker.is_finished()
+                && job
+                    .cdc_table_backfill_tracker
+                    .as_ref()
+                    .is_some_and(|t| !t.is_pre_completed())
+            {
+                return None;
+            }
+            Some(tracker)
         })
     }
 
     fn iter_mut_creating_job_tracker(
         &mut self,
     ) -> impl Iterator<Item = &mut CreateMviewProgressTracker> {
-        self.jobs
-            .values_mut()
-            .filter_map(|job| match &mut job.status {
-                CreateStreamingJobStatus::Init => None,
-                CreateStreamingJobStatus::Creating { tracker, .. } => Some(tracker),
-                CreateStreamingJobStatus::Created => None,
-            })
+        self.jobs.values_mut().filter_map(|job| {
+            let cdc_backfill_pending = job
+                .cdc_table_backfill_tracker
+                .as_ref()
+                .is_some_and(|t| !t.is_pre_completed());
+            match &mut job.status {
+                CreateStreamingJobStatus::Creating { tracker }
+                    if !(tracker.is_finished() && cdc_backfill_pending) =>
+                {
+                    Some(tracker)
+                }
+                _ => None,
+            }
+        })
     }
 
     pub(super) fn has_pending_finished_jobs(&self) -> bool {
-        self.jobs.values().any(|job| {
-            let CreateStreamingJobStatus::Creating { tracker } = &job.status else {
-                return false;
-            };
-            if !tracker.is_finished() {
-                return false;
-            }
-            !job.cdc_table_backfill_tracker
-                .as_ref()
-                .is_some_and(|t| !t.is_pre_completed())
-        })
+        self.iter_creating_job_tracker()
+            .any(|tracker| tracker.is_finished())
     }
 
     pub(super) fn take_pending_backfill_nodes(&mut self) -> Vec<FragmentId> {


### PR DESCRIPTION
## Problem

`WAIT TABLE` on a CDC source-backed table (`CREATE TABLE ... FROM <cdc_source>` with `snapshot=true`) returned immediately instead of waiting for the snapshot backfill to finish.

### Root cause

`WAIT TABLE` unblocks when `job_status` in the DB transitions from `Creating` to `Created`, which happens when `finish_streaming_job` is called. That call is driven by `take_staging_commit_info` pushing a `TrackingJob` into `finished_jobs`, which happens when `CreateMviewProgressTracker::is_finished()` returns true.

For CDC source-backed tables the MV tracker tracks **zero actors** — the CDC snapshot backfill progress flows through a separate `PbCdcTableBackfillProgress` channel to `CdcTableBackfillTracker`, not through `CreateMviewProgress`. Because the MV tracker has nothing to wait for, `is_finished()` is true from the very first barrier, so `finish_streaming_job` fires before any snapshot splits are scanned.

## Design

The state machine stays `Init → Creating → Created`. A CDC source-backed table simply spends more time in `Creating` — the job's `job_status` in the DB stays `Creating` until all CDC snapshot splits are backfilled and the CDC offset has caught up, which is exactly what `WAIT TABLE` polls.

No new enum variants. The `cdc_table_backfill_tracker` field on `InflightStreamingJobInfo` is the CDC gate; `has_pending_finished_jobs` and `take_staging_commit_info` consult it before acting on a finished MV tracker.

## Usage

```sql
SET background_ddl = true;
CREATE TABLE orders FROM my_cdc_source TABLE 'mydb.orders' WITH (snapshot = 'true');
WAIT TABLE orders;  -- now blocks until snapshot backfill is complete