### PR TITLE
feat(iceberg): coordinator-driven size-based commit trigger

### DIFF
--- a/proto/connector_service.proto
+++ b/proto/connector_service.proto
@@ -243,12 +243,18 @@ message CoordinateRequest {
     common.Buffer vnode_bitmap = 1;
   }
 
+  message ReportBytesRequest {
+    uint64 epoch = 1;
+    uint64 buffered_bytes = 2;
+  }
+
   oneof msg {
     StartCoordinationRequest start_request = 1;
     CommitRequest commit_request = 2;
     UpdateVnodeBitmapRequest update_vnode_request = 3;
     bool stop = 4;
     uint64 align_initial_epoch_request = 5;
+    ReportBytesRequest report_bytes_request = 6;
   }
 }
 
@@ -261,11 +267,17 @@ message CoordinateResponse {
     uint64 epoch = 1;
   }
 
+  message ReportBytesResponse {
+    uint64 epoch = 1;
+    bool should_commit = 2;
+  }
+
   oneof msg {
     StartCoordinationResponse start_response = 1;
     CommitResponse commit_response = 2;
     bool stopped = 3;
     uint64 align_initial_epoch_response = 4;
+    ReportBytesResponse report_bytes_response = 5;
   }
 }
 

--- a/src/connector/src/allow_alter_on_fly_fields.rs
+++ b/src/connector/src/allow_alter_on_fly_fields.rs
@@ -234,6 +234,7 @@ pub static SINK_ALLOW_ALTER_ON_FLY_FIELDS: LazyLock<HashMap<String, HashSet<Stri
         std::any::type_name::<IcebergConfig>().to_owned(),
         [
             "commit_checkpoint_interval".to_owned(),
+            "commit_checkpoint_size_threshold_mb".to_owned(),
             "enable_compaction".to_owned(),
             "compaction_interval_sec".to_owned(),
             "enable_snapshot_expiration".to_owned(),

--- a/src/connector/src/sink/coordinate.rs
+++ b/src/connector/src/sink/coordinate.rs
@@ -27,6 +27,7 @@ use tracing::{info, warn};
 use super::{
     LogSinker, SinkCoordinationRpcClientEnum, SinkLogReader, SinkWriterMetrics, SinkWriterParam,
 };
+use crate::sink::iceberg::COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB;
 use crate::sink::writer::SinkWriter;
 use crate::sink::{LogStoreReadItem, Result, SinkError, SinkParam, TruncateOffset};
 
@@ -36,6 +37,7 @@ pub struct CoordinatedLogSinker<W: SinkWriter<CommitMetadata = Option<SinkMetada
     param: SinkParam,
     vnode_bitmap: Bitmap,
     commit_checkpoint_interval: NonZeroU64,
+    commit_checkpoint_size_threshold_bytes: Option<u64>,
     sink_writer_metrics: SinkWriterMetrics,
 }
 
@@ -46,6 +48,11 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> CoordinatedLogSinker<
         writer: W,
         commit_checkpoint_interval: NonZeroU64,
     ) -> Result<Self> {
+        let commit_checkpoint_size_threshold_bytes =
+            param.properties.get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|&mb| mb > 0)
+                .map(|mb| mb.saturating_mul(1024 * 1024));
         Ok(Self {
             writer,
             sink_coordinate_client: writer_param
@@ -64,6 +71,7 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> CoordinatedLogSinker<
                 })?
                 .clone(),
             commit_checkpoint_interval,
+            commit_checkpoint_size_threshold_bytes,
             sink_writer_metrics: SinkWriterMetrics::new(writer_param),
         })
     }
@@ -270,6 +278,40 @@ impl<W: SinkWriter<CommitMetadata = Option<SinkMetadata>>> LogSinker for Coordin
                                 return pending().await;
                             }
                             log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                        } else if self.commit_checkpoint_size_threshold_bytes.is_some() {
+                            let buffered_bytes = sink_writer.buffered_bytes();
+                            // Skip the RPC round-trip when there is no buffered data
+                            if buffered_bytes == 0 {
+                                sink_writer.barrier(false).await?;
+                            } else {
+                                let should_commit = coordinator_stream_handle
+                                    .report_bytes(epoch, buffered_bytes)
+                                    .await?;
+
+                                if should_commit {
+                                    let start_time = Instant::now();
+                                    let metadata = sink_writer.barrier(true).await?;
+                                    let metadata = metadata.ok_or_else(|| {
+                                        SinkError::Coordinator(anyhow!(
+                                            "should get metadata on checkpoint barrier"
+                                        ))
+                                    })?;
+                                    coordinator_stream_handle
+                                        .commit(epoch, metadata, None)
+                                        .await?;
+                                    sink_writer_metrics
+                                        .sink_commit_duration
+                                        .observe(start_time.elapsed().as_secs_f64());
+
+                                    current_checkpoint = 0;
+                                    log_reader.truncate(TruncateOffset::Barrier { epoch })?;
+                                } else {
+                                    let metadata = sink_writer.barrier(false).await?;
+                                    if let Some(metadata) = metadata {
+                                        warn!(?metadata, "get metadata on non-checkpoint barrier");
+                                    }
+                                }
+                            }
                         } else {
                             let metadata = sink_writer.barrier(false).await?;
                             if let Some(metadata) = metadata {

--- a/src/connector/src/sink/decouple_checkpoint_log_sink.rs
+++ b/src/connector/src/sink/decouple_checkpoint_log_sink.rs
@@ -27,12 +27,20 @@ pub const DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITHOUT_SINK_DECOUPLE: u64 = 1;
 pub const ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL: u64 = 60;
 pub const COMMIT_CHECKPOINT_INTERVAL: &str = "commit_checkpoint_interval";
 
+/// 512 MiB default balances Iceberg's recommended on-disk file size (128-512 MiB)
+/// against the ~3-10x in-memory-to-columnar-compressed ratio.
+pub const ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: u64 = 512;
+
 pub fn default_commit_checkpoint_interval() -> u64 {
     DEFAULT_COMMIT_CHECKPOINT_INTERVAL_WITH_SINK_DECOUPLE
 }
 
 pub fn iceberg_default_commit_checkpoint_interval() -> u64 {
     ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL
+}
+
+pub fn default_commit_checkpoint_size_threshold_mb() -> u64 {
+    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB
 }
 
 /// The `LogSinker` implementation used for commit-decoupled sinks (such as `Iceberg`, `DeltaLake` and `StarRocks`).

--- a/src/connector/src/sink/iceberg/config.rs
+++ b/src/connector/src/sink/iceberg/config.rs
@@ -30,7 +30,10 @@ use super::{SINK_TYPE_APPEND_ONLY, SINK_TYPE_OPTION, SINK_TYPE_UPSERT, SinkError
 use crate::connector_common::{IcebergCommon, IcebergTableIdentifier};
 use crate::enforce_secret::EnforceSecret;
 use crate::sink::Result;
-use crate::sink::decouple_checkpoint_log_sink::iceberg_default_commit_checkpoint_interval;
+use crate::sink::decouple_checkpoint_log_sink::{
+    iceberg_default_commit_checkpoint_interval,
+    default_commit_checkpoint_size_threshold_mb,
+};
 use crate::{deserialize_bool_from_string, deserialize_optional_string_seq_from_string};
 
 pub const ICEBERG_COW_BRANCH: &str = "ingestion";
@@ -103,6 +106,7 @@ pub const ENABLE_COMPACTION: &str = "enable_compaction";
 pub const COMPACTION_INTERVAL_SEC: &str = "compaction_interval_sec";
 pub const ENABLE_SNAPSHOT_EXPIRATION: &str = "enable_snapshot_expiration";
 pub const WRITE_MODE: &str = "write_mode";
+pub const COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB: &str = "commit_checkpoint_size_threshold_mb";
 pub const FORMAT_VERSION: &str = "format_version";
 pub const SNAPSHOT_EXPIRATION_RETAIN_LAST: &str = "snapshot_expiration_retain_last";
 pub const SNAPSHOT_EXPIRATION_RETAIN_MAX: &str = "snapshot_expiration_retain_max";
@@ -365,6 +369,20 @@ pub struct IcebergConfig {
     #[serde_as(as = "DisplayFromStr")]
     #[with_option(allow_alter_on_fly)]
     pub commit_checkpoint_interval: u64,
+
+    /// Commit on the next checkpoint barrier after total buffered write size across
+    /// all writers exceeds this threshold in MiB. The coordinator sums per-writer
+    /// byte reports and broadcasts the same commit decision to all writers, ensuring
+    /// vnode-aligned commits at the same epoch.
+    ///
+    /// Default 512 MiB balances Iceberg's recommended file size (128-512 MiB on disk)
+    /// against the ~3-10x in-memory-to-columnar-compressed ratio. At 512 MiB in
+    /// memory, each commit produces ~50-170 MiB Parquet files — within the healthy
+    /// range for analytical queries.
+    #[serde(default = "default_commit_checkpoint_size_threshold_mb")]
+    #[serde_as(as = "DisplayFromStr")]
+    #[with_option(allow_alter_on_fly)]
+    pub commit_checkpoint_size_threshold_mb: u64,
 
     #[serde(default, deserialize_with = "deserialize_bool_from_string")]
     pub create_table_if_not_exists: bool,

--- a/src/connector/src/sink/iceberg/test.rs
+++ b/src/connector/src/sink/iceberg/test.rs
@@ -26,7 +26,10 @@ use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::{DataType, MapType, StructType};
 
 use crate::connector_common::{IcebergCommon, IcebergTableIdentifier};
-use crate::sink::decouple_checkpoint_log_sink::ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL;
+use crate::sink::decouple_checkpoint_log_sink::{
+    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL,
+    ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB,
+};
 use crate::sink::iceberg::{
     COMPACTION_INTERVAL_SEC, COMPACTION_MAX_SNAPSHOTS_NUM,
     COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, CompactionType,
@@ -383,6 +386,7 @@ fn test_parse_iceberg_config() {
                 .map(|(k, v)| (k.to_owned(), v.to_owned()))
                 .collect(),
             commit_checkpoint_interval: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL,
+            commit_checkpoint_size_threshold_mb: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB,
             create_table_if_not_exists: false,
             drop_table_on_sink_drop: false,
             is_exactly_once: Some(true),

--- a/src/connector/src/sink/iceberg/writer.rs
+++ b/src/connector/src/sink/iceberg/writer.rs
@@ -238,6 +238,7 @@ pub struct IcebergSinkWriterInner {
     // For chunk with extra partition column, we should remove this column before write.
     // This project index vec is used to avoid create project idx each time.
     project_idx_vec: ProjectIdxVec,
+    uncommitted_write_bytes: u64,
 }
 
 enum IcebergWriterDispatch {
@@ -414,6 +415,7 @@ impl IcebergSinkWriterInner {
                     ProjectIdxVec::None
                 }
             },
+            uncommitted_write_bytes: 0,
         })
     }
 
@@ -603,6 +605,7 @@ impl IcebergSinkWriterInner {
                     ProjectIdxVec::None
                 }
             },
+            uncommitted_write_bytes: 0,
         })
     }
 
@@ -707,6 +710,7 @@ impl IcebergSinkWriterInner {
             .write(batch)
             .instrument_await("iceberg_write")
             .await?;
+        self.uncommitted_write_bytes += write_batch_size as u64;
         self.metrics.write_bytes.inc_by(write_batch_size as _);
         Ok(())
     }
@@ -730,6 +734,7 @@ impl IcebergSinkWriterInner {
             .write_with_position(batch)
             .instrument_await("iceberg_write")
             .await?;
+        self.uncommitted_write_bytes += write_batch_size as u64;
         self.metrics.write_bytes.inc_by(write_batch_size as _);
         Ok(positions)
     }
@@ -782,6 +787,10 @@ impl IcebergSinkWriterInner {
                 close_result
             }
         };
+        // All buffered data has been flushed to data files, so reset the uncommitted byte
+        // counter. `close()` is the single flush point shared by both the coordinated-sink
+        // barrier path and the V3 writer-executor flush path.
+        self.uncommitted_write_bytes = 0;
         Ok(res)
     }
 
@@ -842,6 +851,13 @@ impl SinkWriter for IcebergSinkWriter {
             unreachable!("IcebergSinkWriter should be initialized before barrier");
         };
         inner.write_batch(chunk).await
+    }
+
+    fn buffered_bytes(&self) -> u64 {
+        match self {
+            Self::Initialized(inner) => inner.uncommitted_write_bytes,
+            Self::Created(_) => 0,
+        }
     }
 
     /// Receive a barrier and mark the end of current epoch. When `is_checkpoint` is true, the sink

--- a/src/connector/src/sink/writer.rs
+++ b/src/connector/src/sink/writer.rs
@@ -42,6 +42,12 @@ pub trait SinkWriter: Send + 'static {
     /// writer should commit the current epoch.
     async fn barrier(&mut self, is_checkpoint: bool) -> Result<Self::CommitMetadata>;
 
+    /// Return the number of uncommitted write bytes buffered by this writer.
+    /// Defaults to 0 for sinks that don't track buffered bytes.
+    fn buffered_bytes(&self) -> u64 {
+        0
+    }
+
     /// Clean up
     async fn abort(&mut self) -> Result<()> {
         Ok(())

--- a/src/connector/with_options_sink.yaml
+++ b/src/connector/with_options_sink.yaml
@@ -705,6 +705,16 @@ IcebergConfig:
     required: false
     default: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_INTERVAL
     allow_alter_on_fly: true
+  - name: commit_checkpoint_size_threshold_mb
+    field_type: u64
+    comments: |-
+      Commit on the next checkpoint barrier after total buffered write size across all
+      writers exceeds this threshold in MiB. The coordinator sums per-writer byte reports
+      and broadcasts the same commit decision to all writers. Default 512 MiB.
+      Set to 0 to disable size-based early commits.
+    required: false
+    default: ICEBERG_DEFAULT_COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB
+    allow_alter_on_fly: true
   - name: create_table_if_not_exists
     field_type: bool
     required: false

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -103,7 +103,8 @@ use risingwave_connector::sink::iceberg::{
     COMPACTION_DELETE_EQUALITY_RECORDS_COUNT_THRESHOLD, COMPACTION_DELETE_FILES_COUNT_THRESHOLD,
     COMPACTION_DELETE_POSITION_RECORDS_COUNT_THRESHOLD, COMPACTION_INTERVAL_SEC,
     COMPACTION_MAX_SNAPSHOTS_NUM, COMPACTION_SMALL_FILES_THRESHOLD_MB,
-    COMPACTION_TARGET_FILE_SIZE_MB, COMPACTION_TRIGGER_SNAPSHOT_COUNT, COMPACTION_TYPE,
+    COMPACTION_TARGET_FILE_SIZE_MB, COMPACTION_TRIGGER_SNAPSHOT_COUNT,     COMPACTION_TYPE,
+    COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB,
     COMPACTION_WRITE_PARQUET_COMPRESSION,
     COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_BYTES, COMPACTION_WRITE_PARQUET_MAX_ROW_GROUP_ROWS,
     CompactionType, ENABLE_COMPACTION, ENABLE_PK_INDEX, ENABLE_SNAPSHOT_EXPIRATION, FORMAT_VERSION,
@@ -1975,6 +1976,26 @@ pub async fn create_iceberg_engine_table(
         COMMIT_CHECKPOINT_INTERVAL.to_owned(),
         commit_checkpoint_interval.to_string(),
     );
+
+    if let Some(commit_checkpoint_size_threshold_mb) =
+        handler_args.with_options.get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
+    {
+        let threshold_mb: u64 = commit_checkpoint_size_threshold_mb.parse().map_err(|_| {
+            ErrorCode::InvalidInputSyntax(format!(
+                "{} must be a positive integer: {}",
+                COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB, commit_checkpoint_size_threshold_mb
+            ))
+        })?;
+        // Setting to 0 disables size-based early commits.
+        if let Some(s) = source.as_mut() {
+            s.with_properties.remove(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB);
+        }
+        sink_with.insert(
+            COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB.to_owned(),
+            threshold_mb.to_string(),
+        );
+    }
+
     sink_with.insert("create_table_if_not_exists".to_owned(), "true".to_owned());
 
     sink_with.insert("is_exactly_once".to_owned(), "true".to_owned());

--- a/src/meta/src/manager/sink_coordination/coordinator_worker.rs
+++ b/src/meta/src/manager/sink_coordination/coordinator_worker.rs
@@ -29,6 +29,7 @@ use risingwave_common::bitmap::Bitmap;
 use risingwave_connector::connector_common::IcebergSinkCompactionUpdate;
 use risingwave_connector::dispatch_sink;
 use risingwave_connector::sink::catalog::SinkId;
+use risingwave_connector::sink::iceberg::COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB;
 use risingwave_connector::sink::{
     Sink, SinkCommitCoordinator, SinkCommittedEpochSubscriber, SinkError, SinkParam, build_sink,
 };
@@ -68,11 +69,18 @@ async fn run_future_with_periodic_fn<F: Future>(
 
 type HandleId = usize;
 
-#[derive(Default)]
 struct AligningRequests<R> {
-    requests: Vec<R>,
-    handle_ids: HashSet<HandleId>,
+    requests: Vec<(HandleId, Bitmap, R)>,
     committed_bitmap: Option<Bitmap>, // lazy-initialized on first request
+}
+
+impl<R> Default for AligningRequests<R> {
+    fn default() -> Self {
+        Self {
+            requests: Vec::default(),
+            committed_bitmap: None,
+        }
+    }
 }
 
 impl<R> AligningRequests<R> {
@@ -97,18 +105,55 @@ impl<R> AligningRequests<R> {
                 check_bitmap.iter_ones().collect_vec(),
                 vnode_bitmap,
                 committed_bitmap,
-                self.requests,
+                self.requests.iter().map(|(_, _, r)| r).collect::<Vec<_>>(),
                 request
             ));
         }
         *committed_bitmap |= vnode_bitmap;
-        self.requests.push(request);
-        assert!(self.handle_ids.insert(handle_id));
+        assert!(
+            !self.requests.iter().any(|(hid, _, _)| *hid == handle_id),
+            "handle {handle_id} already has a pending request for this epoch"
+        );
+        self.requests.push((handle_id, vnode_bitmap.clone(), request));
         Ok(())
     }
 
     fn aligned(&self) -> bool {
         self.committed_bitmap.as_ref().is_some_and(|b| b.all())
+    }
+
+    fn handle_ids(&self) -> impl Iterator<Item = HandleId> + '_ {
+        self.requests.iter().map(|(hid, _, _)| *hid)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
+
+    fn recompute_committed_bitmap(&mut self) {
+        self.committed_bitmap = if self.requests.is_empty() {
+            None
+        } else {
+            let mut bitmap = self.requests[0].1.clone();
+            for (_, b, _) in &self.requests[1..] {
+                bitmap |= b;
+            }
+            Some(bitmap)
+        };
+    }
+
+    fn sync_with_running_handles(
+        &mut self,
+        get_vnode_bitmap: impl Fn(HandleId) -> Option<Bitmap>,
+    ) {
+        for (hid, bitmap, _) in &mut self.requests {
+            if let Some(current) = get_vnode_bitmap(*hid) {
+                *bitmap = current;
+            }
+        }
+        self.requests
+            .retain(|(hid, _, _)| get_vnode_bitmap(*hid).is_some());
+        self.recompute_committed_bitmap();
     }
 }
 
@@ -333,6 +378,31 @@ impl CoordinationHandleManager {
         Ok(())
     }
 
+    fn send_report_bytes_response(
+        &mut self,
+        epoch: u64,
+        should_commit: bool,
+        handle_ids: impl IntoIterator<Item = HandleId>,
+    ) -> anyhow::Result<()> {
+        for handle_id in handle_ids {
+            let handle = self.writer_handles.get_mut(&handle_id).ok_or_else(|| {
+                anyhow!(
+                    "fail to find handle for {} when sending report bytes response on epoch {}",
+                    handle_id,
+                    epoch
+                )
+            })?;
+            handle.send_report_bytes_response(epoch, should_commit).map_err(|_| {
+                anyhow!(
+                    "fail to send report bytes response on epoch {} for handle {}",
+                    epoch,
+                    handle_id
+                )
+            })?;
+        }
+        Ok(())
+    }
+
     async fn next_request_inner(
         writer_handles: &mut HashMap<HandleId, SinkWriterCoordinationHandle>,
     ) -> anyhow::Result<(HandleId, coordinate_request::Msg)> {
@@ -357,6 +427,10 @@ enum CoordinationHandleManagerEvent {
         metadata: SinkMetadata,
         schema_change: Option<PbSinkSchemaChange>,
     },
+    ReportBytes {
+        epoch: u64,
+        buffered_bytes: u64,
+    },
     AlignInitialEpoch(u64),
 }
 
@@ -367,6 +441,7 @@ impl CoordinationHandleManagerEvent {
             CoordinationHandleManagerEvent::UpdateVnodeBitmap => "UpdateVnodeBitmap",
             CoordinationHandleManagerEvent::Stop => "Stop",
             CoordinationHandleManagerEvent::CommitRequest { .. } => "CommitRequest",
+            CoordinationHandleManagerEvent::ReportBytes { .. } => "ReportBytes",
             CoordinationHandleManagerEvent::AlignInitialEpoch(_) => "AlignInitialEpoch",
         }
     }
@@ -391,8 +466,14 @@ impl CoordinationHandleManager {
                     coordinate_request::Msg::CommitRequest(request) => {
                         CoordinationHandleManagerEvent::CommitRequest {
                             epoch: request.epoch,
-                            metadata: request.metadata.ok_or_else(|| anyhow!("empty sink metadata"))?,
+                            metadata: request.metadata.unwrap(),
                             schema_change: request.schema_change,
+                        }
+                    }
+                    coordinate_request::Msg::ReportBytesRequest(request) => {
+                        CoordinationHandleManagerEvent::ReportBytes {
+                            epoch: request.epoch,
+                            buffered_bytes: request.buffered_bytes,
                         }
                     }
                     coordinate_request::Msg::AlignInitialEpochRequest(epoch) => {
@@ -441,7 +522,7 @@ impl CoordinationHandleManager {
                 unexpected_event
             ));
         }
-        Ok(init_requests.handle_ids)
+        Ok(init_requests.handle_ids().collect())
     }
 
     async fn alter_parallelisms(
@@ -455,7 +536,7 @@ impl CoordinationHandleManager {
         let mut remaining_handles: HashSet<_> = self
             .writer_handles
             .keys()
-            .filter(|handle_id| !requests.handle_ids.contains(handle_id))
+            .filter(|handle_id| !requests.handle_ids().any(|h| h == **handle_id))
             .cloned()
             .collect();
         while !remaining_handles.is_empty() || !requests.aligned() {
@@ -479,6 +560,13 @@ impl CoordinationHandleManager {
                         handle_id
                     );
                 }
+                CoordinationHandleManagerEvent::ReportBytes { epoch, .. } => {
+                    bail!(
+                        "receive ReportBytes on epoch {} from handle {} during alter parallelism",
+                        epoch,
+                        handle_id
+                    );
+                }
                 CoordinationHandleManagerEvent::AlignInitialEpoch(epoch) => {
                     bail!(
                         "receive AlignInitialEpoch on epoch {} from handle {} during alter parallelism",
@@ -488,7 +576,7 @@ impl CoordinationHandleManager {
                 }
             }
         }
-        Ok(requests.handle_ids)
+        Ok(requests.handle_ids().collect())
     }
 }
 
@@ -627,6 +715,7 @@ impl CoordinatorWorker {
             let aligned_initial_epoch = align_requests
                 .requests
                 .into_iter()
+                .map(|(_, _, epoch)| epoch)
                 .max()
                 .expect("non-empty");
             self.handle_manager
@@ -680,7 +769,14 @@ impl CoordinatorWorker {
         self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
             .await?;
 
+        let commit_checkpoint_size_threshold_bytes: Option<u64> =
+            self.handle_manager.param.properties.get(COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB)
+                .and_then(|v| v.parse::<u64>().ok())
+                .filter(|&mb| mb > 0)
+                .map(|mb| mb.saturating_mul(1024 * 1024));
+
         let mut pending_epochs: BTreeMap<u64, AligningRequests<_>> = BTreeMap::new();
+        let mut pending_byte_reports: BTreeMap<u64, AligningRequests<u64>> = BTreeMap::new();
         let mut pending_new_handles = vec![];
         loop {
             let event = self.next_event(&mut two_phase_handler).await?;
@@ -697,6 +793,24 @@ impl CoordinatorWorker {
                             .await?;
                         self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
                             .await?;
+                        pending_epochs.retain(|_, align_req| {
+                            align_req.sync_with_running_handles(|hid| {
+                                self.handle_manager
+                                    .writer_handles
+                                    .get(&hid)
+                                    .map(|h| h.vnode_bitmap().clone())
+                            });
+                            !align_req.is_empty()
+                        });
+                        pending_byte_reports.retain(|_, align_req| {
+                            align_req.sync_with_running_handles(|hid| {
+                                self.handle_manager
+                                    .writer_handles
+                                    .get(&hid)
+                                    .map(|h| h.vnode_bitmap().clone())
+                            });
+                            !align_req.is_empty()
+                        });
                         continue;
                     }
                     CoordinationHandleManagerEvent::Stop => {
@@ -707,7 +821,24 @@ impl CoordinatorWorker {
                             .await?;
                         self.try_handle_init_requests(&running_handles, &mut two_phase_handler)
                             .await?;
-
+                        pending_epochs.retain(|_, align_req| {
+                            align_req.sync_with_running_handles(|hid| {
+                                self.handle_manager
+                                    .writer_handles
+                                    .get(&hid)
+                                    .map(|h| h.vnode_bitmap().clone())
+                            });
+                            !align_req.is_empty()
+                        });
+                        pending_byte_reports.retain(|_, align_req| {
+                            align_req.sync_with_running_handles(|hid| {
+                                self.handle_manager
+                                    .writer_handles
+                                    .get(&hid)
+                                    .map(|h| h.vnode_bitmap().clone())
+                            });
+                            !align_req.is_empty()
+                        });
                         continue;
                     }
                     CoordinationHandleManagerEvent::CommitRequest {
@@ -717,6 +848,46 @@ impl CoordinatorWorker {
                     } => (handle_id, epoch, (metadata, schema_change)),
                     CoordinationHandleManagerEvent::AlignInitialEpoch(_) => {
                         bail!("receive AlignInitialEpoch after initialization")
+                    }
+                    CoordinationHandleManagerEvent::ReportBytes {
+                        epoch,
+                        buffered_bytes,
+                    } => {
+                        if !running_handles.contains(&handle_id) {
+                            bail!(
+                                "receiving report bytes from non-running handle {}, running handles: {:?}",
+                                handle_id,
+                                running_handles
+                            );
+                        }
+                        pending_byte_reports
+                            .entry(epoch)
+                            .or_default()
+                            .add_new_request(
+                                handle_id,
+                                buffered_bytes,
+                                self.handle_manager.vnode_bitmap(handle_id),
+                            )?;
+                        if pending_byte_reports
+                            .first_key_value()
+                            .expect("non-empty")
+                            .1
+                            .aligned()
+                        {
+                            let (report_epoch, reports) =
+                                pending_byte_reports.pop_first().expect("non-empty");
+                            let total_bytes: u64 = reports.requests.iter().map(|(_, _, b)| *b).sum();
+                            let should_commit =
+                                commit_checkpoint_size_threshold_bytes.is_some_and(|threshold| {
+                                    total_bytes > 0 && total_bytes >= threshold
+                                });
+                            self.handle_manager.send_report_bytes_response(
+                                report_epoch,
+                                should_commit,
+                                reports.handle_ids(),
+                            )?;
+                        }
+                        continue;
                     }
                 },
                 CoordinatorWorkerEvent::ReadyToCommit(epoch, metadata, schema_change) => {
@@ -803,10 +974,12 @@ impl CoordinatorWorker {
             {
                 let (epoch, commit_requests) = pending_epochs.pop_first().expect("non-empty");
                 let mut metadatas = Vec::with_capacity(commit_requests.requests.len());
+                let handle_ids: Vec<HandleId> = commit_requests.handle_ids().collect();
                 let mut requests = commit_requests.requests.into_iter();
-                let (first_metadata, first_schema_change) = requests.next().expect("non-empty");
+                let (_, _, (first_metadata, first_schema_change)) =
+                    requests.next().expect("non-empty");
                 metadatas.push(first_metadata);
-                for (metadata, schema_change) in requests {
+                for (_, _, (metadata, schema_change)) in requests {
                     if first_schema_change != schema_change {
                         return Err(anyhow!(
                             "got different schema change {:?} to prev schema change {:?}",
@@ -877,7 +1050,7 @@ impl CoordinatorWorker {
                 }
 
                 self.handle_manager
-                    .ack_commit(epoch, commit_requests.handle_ids)?;
+                    .ack_commit(epoch, handle_ids)?;
                 self.last_writer_acked_epoch = Some(epoch);
             }
         }

--- a/src/meta/src/manager/sink_coordination/handle.rs
+++ b/src/meta/src/manager/sink_coordination/handle.rs
@@ -102,6 +102,23 @@ impl SinkWriterCoordinationHandle {
             .map_err(|_| anyhow!("fail to send commit response of epoch {}", epoch))
     }
 
+    pub(super) fn send_report_bytes_response(
+        &mut self,
+        epoch: u64,
+        should_commit: bool,
+    ) -> anyhow::Result<()> {
+        self.response_tx
+            .send(Ok(CoordinateResponse {
+                msg: Some(coordinate_response::Msg::ReportBytesResponse(
+                    coordinate_response::ReportBytesResponse {
+                        epoch,
+                        should_commit,
+                    },
+                )),
+            }))
+            .map_err(|_| anyhow!("fail to send report bytes response"))
+    }
+
     pub(super) fn stop(&mut self) -> anyhow::Result<()> {
         self.response_tx
             .send(Ok(CoordinateResponse {
@@ -121,7 +138,8 @@ impl SinkWriterCoordinationHandle {
             match &request {
                 coordinate_request::Msg::StartRequest(_)
                 | coordinate_request::Msg::Stop(_)
-                | coordinate_request::Msg::AlignInitialEpochRequest(_) => {}
+                | coordinate_request::Msg::AlignInitialEpochRequest(_)
+                | coordinate_request::Msg::ReportBytesRequest(_) => {}
                 coordinate_request::Msg::CommitRequest(request) => {
                     if let Some(prev_epoch) = self.prev_epoch
                         && request.epoch < prev_epoch

--- a/src/meta/src/manager/sink_coordination/manager.rs
+++ b/src/meta/src/manager/sink_coordination/manager.rs
@@ -404,6 +404,7 @@ impl ManagerWorker {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::future::{Future, poll_fn};
     use std::pin::pin;
     use std::sync::Arc;
@@ -419,6 +420,7 @@ mod tests {
     use risingwave_common::bitmap::BitmapBuilder;
     use risingwave_common::hash::VirtualNode;
     use risingwave_connector::sink::catalog::{SinkId, SinkType};
+    use risingwave_connector::sink::iceberg::COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB;
     use risingwave_connector::sink::{
         SinglePhaseCommitCoordinator, SinkCommitCoordinator, SinkError, SinkParam,
         TwoPhaseCommitCoordinator,
@@ -956,6 +958,262 @@ mod tests {
         );
         drop(client2);
         assert!(commit_future.await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_size_based_commit_via_coordinator() {
+        let db = prepare_db_backend().await;
+
+        let mut properties = BTreeMap::new();
+        properties.insert(
+            COMMIT_CHECKPOINT_SIZE_THRESHOLD_MB.to_owned(),
+            "1".to_owned(),
+        );
+
+        let param = SinkParam {
+            sink_id: SinkId::from(1),
+            sink_name: "test".into(),
+            properties,
+            columns: vec![],
+            downstream_pk: None,
+            sink_type: SinkType::AppendOnly,
+            ignore_delete: false,
+            format_desc: None,
+            db_name: "test".into(),
+            sink_from_name: "test".into(),
+        };
+
+        let epoch1 = 233;
+        let epoch2 = 234;
+        let epoch3 = 235;
+
+        let mut all_vnode = (0..VirtualNode::COUNT_FOR_TEST).collect_vec();
+        all_vnode.shuffle(&mut rand::rng());
+        let (first, second) = all_vnode.split_at(VirtualNode::COUNT_FOR_TEST / 2);
+        let build_bitmap = |indexes: &[usize]| {
+            let mut builder = BitmapBuilder::zeroed(VirtualNode::COUNT_FOR_TEST);
+            for i in indexes {
+                builder.set(*i, true);
+            }
+            builder.finish()
+        };
+        let vnode1 = build_bitmap(first);
+        let vnode2 = build_bitmap(second);
+
+        let metadata = [
+            [vec![1u8, 2u8], vec![3u8, 4u8]],
+            [vec![5u8, 6u8], vec![]],
+        ];
+        let sender = Arc::new(tokio::sync::Mutex::new(None));
+        let mock_subscriber: SinkCommittedEpochSubscriber = {
+            let captured_sender = sender.clone();
+            Arc::new(move |_sink_id: SinkId| {
+                let (sender, receiver) = unbounded_channel();
+                let captured_sender = captured_sender.clone();
+                async move {
+                    let mut guard = captured_sender.lock().await;
+                    *guard = Some(sender);
+                    Ok((1, receiver))
+                }
+                .boxed()
+            })
+        };
+
+        let (manager, (_join_handle, _stop_tx)) =
+            SinkCoordinatorManager::start_worker_with_spawn_worker({
+                let expected_param = param.clone();
+                let metadata = metadata.clone();
+                let db = db.clone();
+                move |param, new_writer_rx| {
+                    let metadata = metadata.clone();
+                    let expected_param = expected_param.clone();
+                    let db = db.clone();
+                    tokio::spawn({
+                        let subscriber = mock_subscriber.clone();
+                        async move {
+                            assert_eq!(param, expected_param);
+                            CoordinatorWorker::execute_coordinator(
+                                db,
+                                param.clone(),
+                                new_writer_rx,
+                                MockSinglePhaseCoordinator::new_coordinator(
+                                    0,
+                                    move |epoch, metadata_list, count: &mut usize| {
+                                        *count += 1;
+                                        let mut metadata_list =
+                                            metadata_list
+                                                .into_iter()
+                                                .map(|m| match m {
+                                                    SinkMetadata {
+                                                        metadata:
+                                                            Some(Metadata::Serialized(
+                                                                SerializedMetadata { metadata },
+                                                            )),
+                                                    } => metadata,
+                                                    _ => unreachable!(),
+                                                })
+                                                .collect_vec();
+                                        metadata_list.sort();
+                                        match *count {
+                                            1 => {
+                                                assert_eq!(epoch, epoch2);
+                                                assert_eq!(2, metadata_list.len());
+                                                assert_eq!(metadata[0][0], metadata_list[0]);
+                                                assert_eq!(metadata[0][1], metadata_list[1]);
+                                            }
+                                            2 => {
+                                                assert_eq!(epoch, epoch3);
+                                                assert_eq!(2, metadata_list.len());
+                                                assert_eq!(metadata[1][1], metadata_list[0]);
+                                                assert_eq!(metadata[1][0], metadata_list[1]);
+                                            }
+                                            _ => unreachable!(),
+                                        }
+                                        Ok(())
+                                    },
+                                ),
+                                subscriber.clone(),
+                            )
+                            .await;
+                        }
+                    })
+                }
+            });
+
+        let build_client = |vnode| async {
+            CoordinatorStreamHandle::new_with_init_stream(param.to_proto(), vnode, |rx| async {
+                Ok(tonic::Response::new(
+                    manager
+                        .handle_new_request(ReceiverStream::new(rx).map(Ok).boxed())
+                        .await
+                        .unwrap()
+                        .boxed(),
+                ))
+            })
+            .await
+            .unwrap()
+            .0
+        };
+
+        let (mut client1, mut client2) =
+            join(build_client(vnode1), pin!(build_client(vnode2))).await;
+
+        let (aligned_epoch1, aligned_epoch2) = try_join(
+            client1.align_initial_epoch(epoch1),
+            client2.align_initial_epoch(epoch1),
+        )
+        .await
+        .unwrap();
+        assert_eq!(aligned_epoch1, epoch1);
+        assert_eq!(aligned_epoch2, epoch1);
+
+        // Report bytes below the 1MB threshold: each writer reports 400KB,
+        // total 800KB < 1MB → should_commit=false
+        {
+            let mut report_future1 = pin!(client1.report_bytes(epoch1, 409600));
+            assert!(
+                poll_fn(|cx| Poll::Ready(report_future1.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+            let (result1, result2) = join(
+                report_future1,
+                client2.report_bytes(epoch1, 409600),
+            )
+            .await;
+            assert!(!result1.unwrap());
+            assert!(!result2.unwrap());
+        }
+
+        // Report bytes exceeding the 1MB threshold: each writer reports 600KB,
+        // total 1.2MB ≥ 1MB → should_commit=true
+        {
+            let mut report_future1 = pin!(client1.report_bytes(epoch2, 614400));
+            assert!(
+                poll_fn(|cx| Poll::Ready(report_future1.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+            let (result1, result2) = join(
+                report_future1,
+                client2.report_bytes(epoch2, 614400),
+            )
+            .await;
+            assert!(result1.unwrap());
+            assert!(result2.unwrap());
+        }
+
+        // Both writers commit at the same epoch after should_commit=true
+        {
+            let mut commit_future = pin!(
+                client2
+                    .commit(
+                        epoch2,
+                        SinkMetadata {
+                            metadata: Some(Metadata::Serialized(SerializedMetadata {
+                                metadata: metadata[0][1].clone(),
+                            })),
+                        },
+                        None,
+                    )
+                    .map(|result| result.unwrap())
+            );
+            assert!(
+                poll_fn(|cx| Poll::Ready(commit_future.as_mut().poll(cx)))
+                    .await
+                    .is_pending()
+            );
+            join(
+                commit_future,
+                client1
+                    .commit(
+                        epoch2,
+                        SinkMetadata {
+                            metadata: Some(Metadata::Serialized(SerializedMetadata {
+                                metadata: metadata[0][0].clone(),
+                            })),
+                        },
+                        None,
+                    )
+                    .map(|result| result.unwrap()),
+            )
+            .await;
+        }
+
+        // Next round: report bytes above threshold again and commit at epoch3
+        {
+            let (result1, result2) = join(
+                client1.report_bytes(epoch3, 2_000_000),
+                client2.report_bytes(epoch3, 2_000_000),
+            )
+            .await;
+            assert!(result1.unwrap());
+            assert!(result2.unwrap());
+
+            let (result1, result2) = join(
+                client1.commit(
+                    epoch3,
+                    SinkMetadata {
+                        metadata: Some(Metadata::Serialized(SerializedMetadata {
+                            metadata: metadata[1][0].clone(),
+                        })),
+                    },
+                    None,
+                ),
+                client2.commit(
+                    epoch3,
+                    SinkMetadata {
+                        metadata: Some(Metadata::Serialized(SerializedMetadata {
+                            metadata: metadata[1][1].clone(),
+                        })),
+                    },
+                    None,
+                ),
+            )
+            .await;
+            result1.unwrap();
+            result2.unwrap();
+        }
     }
 
     #[tokio::test]

--- a/src/rpc_client/src/sink_coordinate_client.rs
+++ b/src/rpc_client/src/sink_coordinate_client.rs
@@ -115,6 +115,36 @@ impl CoordinatorStreamHandle {
         }
     }
 
+    pub async fn report_bytes(
+        &mut self,
+        epoch: u64,
+        buffered_bytes: u64,
+    ) -> anyhow::Result<bool> {
+        self.send_request(CoordinateRequest {
+            msg: Some(coordinate_request::Msg::ReportBytesRequest(
+                coordinate_request::ReportBytesRequest {
+                    epoch,
+                    buffered_bytes,
+                },
+            )),
+        })
+        .await?;
+        match self.next_response().await? {
+            CoordinateResponse {
+                msg: Some(coordinate_response::Msg::ReportBytesResponse(
+                    coordinate_response::ReportBytesResponse {
+                        should_commit,
+                        ..
+                    },
+                )),
+            } => Ok(should_commit),
+            msg => Err(anyhow!(
+                "should get report bytes response but get {:?}",
+                msg
+            )),
+        }
+    }
+
     pub async fn update_vnode_bitmap(&mut self, vnode_bitmap: &Bitmap) -> anyhow::Result<u64> {
         self.send_request(CoordinateRequest {
             msg: Some(coordinate_request::Msg::UpdateVnodeRequest(


### PR DESCRIPTION
## Motivation

RisingWave's Iceberg sink currently commits data only after a fixed number of checkpoint barriers, controlled by `commit_checkpoint_interval` (default: **60 checkpoints**).

For high-throughput streaming workloads or large backfills, this means uncommitted data can continue accumulating until the next scheduled commit. As ingestion rate increases, both in-memory buffers and state grow without bound, potentially leading to excessive memory usage or even OOM.

Introducing a **size-based commit trigger** addresses this problem by allowing commits to occur once the amount of buffered data exceeds a configurable threshold.

However, implementing this in the coordinated Iceberg sink requires preserving the sink's two-phase commit protocol. All parallel writers must commit the **same epoch**, and the coordinator can only finalize an Iceberg commit after receiving metadata covering every vnode.

If each writer independently triggered a commit when its local buffered bytes exceeded the threshold, writers would reach the threshold at different times. Some writers would flush while others continued buffering, preventing any epoch from achieving complete vnode coverage and potentially causing the coordinated commit to deadlock.

---

## Design

The size-based commit decision is centralized in the **coordinator**, the only component with a complete view of buffered data across all writers.

Instead of making local commit decisions, writers periodically report their buffered bytes to the coordinator during checkpoint barriers. Once reports from all participating writers are received, the coordinator computes the total buffered bytes and determines whether the current epoch should be committed.

The coordinator then broadcasts the same decision (`should_commit`) back to every writer, ensuring that all writers either commit or continue buffering together.

This preserves the existing barrier alignment guarantees while enabling commits to occur earlier when memory usage becomes excessive.

---

## Architecture

```mermaid
sequenceDiagram
    participant W1 as Writer 1
    participant W2 as Writer N
    participant C as Coordinator
    participant T as Iceberg Table

    Note over W1,W2: Writers accumulate uncommitted_write_bytes during write_batch()

    loop Every checkpoint barrier (when interval commit not reached)
        W1->>C: ReportBytes{epoch, buffered_bytes}
        W2->>C: ReportBytes{epoch, buffered_bytes}

        Note over C: Wait until reports cover all vnodes
        C->>C: total_bytes = sum(all writers)
        C->>C: should_commit = total_bytes >= threshold

        alt Threshold reached
            C-->>W1: ReportBytesResponse{should_commit=true}
            C-->>W2: ReportBytesResponse{should_commit=true}

            Note over W1,W2: Every writer takes the same branch

            W1->>W1: barrier(true)
            W2->>W2: barrier(true)

            W1->>C: Commit metadata
            W2->>C: Commit metadata

            C->>T: FastAppend data files

            Note over W1,W2: Reset buffered bytes and checkpoint counter

        else Threshold not reached
            C-->>W1: ReportBytesResponse{should_commit=false}
            C-->>W2: ReportBytesResponse{should_commit=false}

            W1->>W1: barrier(false)
            W2->>W2: barrier(false)
        end
    end

    Note over W1,W2: Interval-based commits remain as the upper bound
```

---

## Commit Flow

```mermaid
flowchart TD
    A["Checkpoint barrier received"]
    --> B{"Forced commit?\n(interval / vnode change / stop / schema change)"}

    B -->|Yes| C["barrier(true)\nFlush\nCommit\nReset"]

    B -->|No| D{"Size threshold enabled?"}

    D -->|No| E["barrier(false)\nContinue buffering"]

    D -->|Yes| F{"Buffered bytes > 0?"}

    F -->|No| E

    F -->|Yes| G["ReportBytes RPC"]

    G --> H{"Coordinator:\nTotal buffered bytes >= threshold?"}

    H -->|Yes| C

    H -->|No| E
```
---

## Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| **512 MiB default threshold** | Balances Iceberg's recommended Parquet file size (128–512 MiB) against the typical **3–10×** reduction from in-memory row representation to compressed columnar storage. A 512 MiB in-memory threshold generally produces **50–170 MiB** Parquet files, which falls within a healthy range for analytical workloads. |
| **Coordinator-driven decision** | Only the coordinator has a global view of buffered data across all writers. Broadcasting a single `should_commit` decision guarantees all writers remain barrier-aligned and eliminates commit divergence. |
| **In-memory byte accounting** | Uses `chunk.estimated_heap_size()` to estimate buffered data at write time. Actual Parquet file size is unknown until files are flushed, making heap size the best available proxy. |
| **Skip RPC for zero buffered bytes** | Writers with no buffered data immediately execute `barrier(false)` without contacting the coordinator, avoiding unnecessary RPC overhead. |
| **Feature can be disabled** | Setting `commit_checkpoint_size_threshold_mb = 0` restores the existing interval-only behavior. |
| **Rescale-safe implementation** | `AligningRequests` tracks `(HandleId, Bitmap, Request)`. During rescaling, `sync_with_running_handles()` refreshes vnode ownership, removes departed writers, and keeps both commit coordination and byte-report state consistent. |

---

## What "Size" Means

The threshold introduced by this PR measures **in-memory buffered data**, not the size of Parquet files written to storage.

After reviewing implementations across Apache Iceberg, Flink, Spark, Trino, Delta Lake, Apache Hudi, and Redpanda:

- **Apache Iceberg**
  - `write.target-file-size-bytes` controls **Parquet file rolling** based on the compressed file size on disk.
  - It is **not** used to determine when an Iceberg commit occurs.

- **This PR**
  - Uses the sum of `chunk.estimated_heap_size()` across all writers.
  - Represents buffered rows in memory before serialization.
  - Typically **3–10× larger** than the resulting compressed Parquet files.

- **Other engines**
  - No existing Iceberg engine performs true size-based commit triggering.
  - Most rely on checkpoint or trigger intervals while using `write.target-file-size-bytes` solely for file rolling.
  - The closest comparable designs are:
    - **Redpanda**, which combines `flush_bytes` and `target_lag_ms`.
    - **Apache Hudi**, which uses `write.batch.size` (default 256 MiB).

---

## Rescaling

`AligningRequests` maintains the vnode bitmap for each active writer.

Following a parallelism change, the coordinator invokes `sync_with_running_handles()` to:

- remove writers that no longer exist,
- refresh vnode ownership for surviving writers, and
- update both pending commit requests and byte-report state.

This ensures commit coordination remains correct across rescaling events without requiring special handling in the writers.

---

## Configuration

Enable the feature (default):

```sql
CREATE SINK s
FROM t
WITH (
    connector = 'iceberg',
    commit_checkpoint_size_threshold_mb = '512'
);
```

Disable the feature:

```sql
CREATE SINK s
FROM t
WITH (
    connector = 'iceberg',
    commit_checkpoint_size_threshold_mb = '0'
);
```

| Option | Type | Default | Description |
|---------|------|---------|-------------|
| `commit_checkpoint_size_threshold_mb` | `u64` | `512` | Triggers an early Iceberg commit when the total buffered bytes across all writers reach or exceed the configured threshold. Set to `0` to disable size-based commits and use interval-only commits. |