### PR TITLE
perf(connector/spanner-cdc): build change-record context once per record

### DIFF
--- a/src/connector/src/source/spanner_cdc/SPANNER_CDC.md
+++ b/src/connector/src/source/spanner_cdc/SPANNER_CDC.md
@@ -741,7 +741,7 @@ PROTO types are mapped to `BYTEA` and ENUM types map to `VARCHAR`. If you see NU
 | `mod.rs` | Source properties (`SpannerCdcProperties`) and connector constants |
 | `enumerator/mod.rs` | Split enumeration (`SpannerCdcSplitEnumerator`) — creates single split with `split_id = source_id.as_raw_id()` |
 | `source/reader.rs` | CDC streaming reader — follows Debezium pattern (background task → mpsc channel → rx.recv) |
-| `source/message.rs` | `TaggedChangeRecord → SourceMessage` conversion; uses `SourceMeta::DebeziumCdc` so messages flow through the standard Debezium CDC path in `PlainParser` |
+| `source/message.rs` | `Mod → SourceMessage` conversion (via `ChangeRecordContext`, built once per `DataChangeRecord`); uses `SourceMeta::DebeziumCdc` so messages flow through the standard Debezium CDC path in `PlainParser` |
 | `split.rs` | Split definition (`SpannerCdcSplit`) — partition token, parent tokens, offset, index |
 | `schema_track.rs` | Shared schema registry for automatic schema evolution; deduplicates schema change events across partitions; emits Debezium-format JSON schema change messages |
 | `types.rs` | Spanner data type definitions, JSON serialization, and `spanner_type_name_to_rw_type` mapping used during schema change parsing |

--- a/src/connector/src/source/spanner_cdc/source/message.rs
+++ b/src/connector/src/source/spanner_cdc/source/message.rs
@@ -12,69 +12,256 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_pb::connector_service::{SourceType, cdc_message};
+use std::collections::HashMap;
 
-use crate::source::SourceMeta;
+use risingwave_pb::connector_service::{SourceType, cdc_message};
+use time::OffsetDateTime;
+
 use crate::source::base::SourceMessage;
 use crate::source::cdc::DebeziumCdcMeta;
-use crate::source::spanner_cdc::types::{DataChangeRecord, Mod};
-use crate::source::{SplitId};
+use crate::source::spanner_cdc::types::{DataChangeRecord, Mod, TypeCode};
+use crate::source::{SourceMeta, SplitId};
 
-/// Tagged change record with split information
-#[derive(Debug, Clone)]
-pub struct TaggedChangeRecord {
-    pub split_id: SplitId,
-    pub database_name: String,
-    pub data_change: DataChangeRecord,
-    pub modification: Mod,
+/// The parts of a `DataChangeRecord` needed to turn each of its `Mod`s into a
+/// [`SourceMessage`], borrowed rather than owned.
+///
+/// A `DataChangeRecord` owns its whole `mods` vector, so cloning one per modification
+/// copies the entire record payload once per row it contains. Nothing downstream reads
+/// `mods`, so this context deliberately excludes it and holds only borrows: it is built
+/// once per record and shared by every mod.
+pub struct ChangeRecordContext<'a> {
+    pub database_name: &'a str,
+    pub table_name: &'a str,
+    pub mod_type: &'a str,
+    pub commit_timestamp: OffsetDateTime,
+    pub column_types: &'a HashMap<&'a str, TypeCode>,
 }
 
-impl From<TaggedChangeRecord> for SourceMessage {
-    fn from(record: TaggedChangeRecord) -> Self {
-        let commit_timestamp = record.data_change.commit_time();
-        // The offset will be set by the reader to include full partition state
-        // Default to the commit timestamp nanos
-        let offset = commit_timestamp.unix_timestamp_nanos().to_string();
-        let source_ts_ms = (commit_timestamp.unix_timestamp_nanos() / 1_000_000) as i64;
-        // Wrap in a Debezium-compatible envelope: {"payload": {"before":..,"after":..,"op":..,"source":..}}
-        // The shared CDC source schema has a `payload` JSONB column; the parser extracts
-        // the top-level "payload" field.  Without this wrapper the field is missing and the
-        // column is padded with NULL, which causes the backfill executor to panic.
-        // The `source` sub-object mirrors the Debezium source envelope so that INCLUDE TIMESTAMP,
-        // INCLUDE database_name, and INCLUDE table_name columns resolve correctly when
-        // parse_debezium_chunk re-parses the stored payload without row_meta.
-        let mod_json = record
-            .modification
-            .to_json_map(&record.data_change.mod_type, &record.data_change)
-            .and_then(|mut inner| {
-                let mut source = serde_json::Map::new();
-                source.insert("ts_ms".to_string(), serde_json::Value::from(source_ts_ms));
-                source.insert(
-                    "db".to_string(),
-                    serde_json::Value::String(record.database_name.clone()),
-                );
-                source.insert(
-                    "table".to_string(),
-                    serde_json::Value::String(record.data_change.table_name.clone()),
-                );
-                inner.insert("source".to_string(), serde_json::Value::Object(source));
-                let mut envelope = serde_json::Map::new();
-                envelope.insert("payload".to_string(), serde_json::Value::Object(inner));
-                serde_json::to_vec(&envelope).map_err(Into::into)
-            })
-            .expect("Spanner change record serialization to JSON should never fail");
-
-        SourceMessage {
-            key: None,
-            payload: Some(mod_json.into()),
-            offset,
-            split_id: record.split_id,
-            meta: SourceMeta::DebeziumCdc(DebeziumCdcMeta::new(
-                record.data_change.table_name.clone(),
-                source_ts_ms,
-                cdc_message::CdcMessageType::Data,
-                SourceType::Unspecified,
-            )),
+impl<'a> ChangeRecordContext<'a> {
+    pub fn new(
+        database_name: &'a str,
+        data_change: &'a DataChangeRecord,
+        column_types: &'a HashMap<&'a str, TypeCode>,
+    ) -> Self {
+        Self {
+            database_name,
+            table_name: &data_change.table_name,
+            mod_type: &data_change.mod_type,
+            commit_timestamp: data_change.commit_time(),
+            column_types,
         }
+    }
+}
+
+/// Build the `SourceMessage` for a single modification of a change record.
+///
+/// `offset` is the partition-watermark offset computed by the reader for the whole record.
+pub fn build_source_message(
+    split_id: &SplitId,
+    ctx: &ChangeRecordContext<'_>,
+    modification: &Mod,
+    offset: &str,
+) -> SourceMessage {
+    let source_ts_ms = (ctx.commit_timestamp.unix_timestamp_nanos() / 1_000_000) as i64;
+    // Wrap in a Debezium-compatible envelope: {"payload": {"before":..,"after":..,"op":..,"source":..}}
+    // The shared CDC source schema has a `payload` JSONB column; the parser extracts
+    // the top-level "payload" field.  Without this wrapper the field is missing and the
+    // column is padded with NULL, which causes the backfill executor to panic.
+    // The `source` sub-object mirrors the Debezium source envelope so that INCLUDE TIMESTAMP,
+    // INCLUDE database_name, and INCLUDE table_name columns resolve correctly when
+    // parse_debezium_chunk re-parses the stored payload without row_meta.
+    let mod_json = modification
+        .to_json_map(ctx.mod_type, ctx.column_types)
+        .and_then(|mut inner| {
+            let mut source = serde_json::Map::new();
+            source.insert("ts_ms".to_string(), serde_json::Value::from(source_ts_ms));
+            source.insert(
+                "db".to_string(),
+                serde_json::Value::String(ctx.database_name.to_owned()),
+            );
+            source.insert(
+                "table".to_string(),
+                serde_json::Value::String(ctx.table_name.to_owned()),
+            );
+            inner.insert("source".to_string(), serde_json::Value::Object(source));
+            let mut envelope = serde_json::Map::new();
+            envelope.insert("payload".to_string(), serde_json::Value::Object(inner));
+            serde_json::to_vec(&envelope).map_err(Into::into)
+        })
+        .expect("Spanner change record serialization to JSON should never fail");
+
+    SourceMessage {
+        key: None,
+        payload: Some(mod_json.into()),
+        offset: offset.to_owned(),
+        split_id: split_id.clone(),
+        meta: SourceMeta::DebeziumCdc(DebeziumCdcMeta::new(
+            ctx.table_name.to_owned(),
+            source_ts_ms,
+            cdc_message::CdcMessageType::Data,
+            SourceType::Unspecified,
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::util::iter_util::ZipEqFast;
+    use time::OffsetDateTime;
+
+    use super::*;
+    use crate::source::cdc::CdcMessageType;
+    use crate::source::spanner_cdc::types::{ColumnType, SpannerType, TypeCode};
+
+    const DB: &str = "test-db";
+    const TABLE: &str = "accounts";
+    const COMMIT_UNIX: i64 = 1_700_000_000;
+    const OFFSET: &str = r#"{"Spanner":{"micros":1700000000000000}}"#;
+
+    fn column(name: &str, code: TypeCode, ordinal: i64) -> ColumnType {
+        ColumnType {
+            name: name.to_owned(),
+            spanner_type: SpannerType::simple(code),
+            is_primary_key: ordinal == 1,
+            ordinal_position: ordinal,
+        }
+    }
+
+    fn insert_mod(id: i64, owner: &str) -> Mod {
+        Mod {
+            keys: Some(format!(r#"{{"id":"{id}"}}"#)),
+            new_values: Some(format!(r#"{{"owner":"{owner}"}}"#)),
+            old_values: None,
+        }
+    }
+
+    /// One record carrying three modifications, as Spanner emits for a
+    /// multi-row transaction.
+    fn multi_mod_record() -> DataChangeRecord {
+        DataChangeRecord {
+            commit_timestamp: OffsetDateTime::from_unix_timestamp(COMMIT_UNIX).unwrap(),
+            record_sequence: "0".to_owned(),
+            server_transaction_id: "txn-1".to_owned(),
+            is_last_record_in_transaction_in_partition: true,
+            table_name: TABLE.to_owned(),
+            value_capture_type: "OLD_AND_NEW_VALUES".to_owned(),
+            column_types: vec![
+                column("id", TypeCode::Int64, 1),
+                column("owner", TypeCode::String, 2),
+            ],
+            mods: vec![
+                insert_mod(1, "alice"),
+                insert_mod(2, "bob"),
+                insert_mod(3, "carol"),
+            ],
+            mod_type: "INSERT".to_owned(),
+            // Counts records in the transaction, not rows: this is one record.
+            number_of_records_in_transaction: 1,
+            number_of_partitions_in_transaction: 1,
+            transaction_tag: String::new(),
+            is_system_transaction: false,
+        }
+    }
+
+    fn build_all(record: &DataChangeRecord) -> Vec<SourceMessage> {
+        let split_id: SplitId = "0".into();
+        let column_types = record.column_type_map();
+        let ctx = ChangeRecordContext::new(DB, record, &column_types);
+        record
+            .mods
+            .iter()
+            .map(|m| build_source_message(&split_id, &ctx, m, OFFSET))
+            .collect()
+    }
+
+    fn payload_of(msg: &SourceMessage) -> serde_json::Value {
+        let bytes = msg.payload.as_ref().expect("payload must be present");
+        let envelope: serde_json::Value = serde_json::from_slice(bytes).unwrap();
+        envelope["payload"].clone()
+    }
+
+    /// Every mod must produce its own message with its own row data — the
+    /// per-record context is shared, the row data is not.
+    #[test]
+    fn test_multi_mod_record_yields_independent_messages() {
+        let record = multi_mod_record();
+        let msgs = build_all(&record);
+
+        assert_eq!(msgs.len(), 3);
+
+        let expected = [(1, "alice"), (2, "bob"), (3, "carol")];
+        for (msg, (id, owner)) in msgs.iter().zip_eq_fast(expected) {
+            let payload = payload_of(msg);
+            assert_eq!(payload["op"], serde_json::Value::String("c".to_owned()));
+            assert_eq!(payload["before"], serde_json::Value::Null);
+            // INT64 key coerced to a JSON number via the shared type map.
+            assert_eq!(payload["after"]["id"], serde_json::Value::from(id));
+            assert_eq!(
+                payload["after"]["owner"],
+                serde_json::Value::String(owner.to_owned())
+            );
+        }
+    }
+
+    /// The fields derived from the record header must be identical across every
+    /// message, and must match the record they came from.
+    #[test]
+    fn test_multi_mod_record_shares_record_level_fields() {
+        let record = multi_mod_record();
+        let msgs = build_all(&record);
+        let expected_ts_ms = COMMIT_UNIX * 1_000;
+
+        for msg in &msgs {
+            let payload = payload_of(msg);
+            let source = &payload["source"];
+            assert_eq!(source["db"], serde_json::Value::String(DB.to_owned()));
+            assert_eq!(source["table"], serde_json::Value::String(TABLE.to_owned()));
+            assert_eq!(source["ts_ms"], serde_json::Value::from(expected_ts_ms));
+
+            assert_eq!(msg.offset, OFFSET);
+            assert_eq!(msg.split_id.as_ref(), "0");
+            let SourceMeta::DebeziumCdc(meta) = &msg.meta else {
+                panic!("expected DebeziumCdc meta");
+            };
+            assert_eq!(meta.full_table_name, TABLE);
+            assert_eq!(meta.source_ts_ms, expected_ts_ms);
+            // `CdcMessageType` derives only Clone + Debug, so match instead of compare.
+            assert!(matches!(meta.msg_type, CdcMessageType::Data));
+        }
+    }
+
+    /// A record whose mods carry different shapes must not leak one row's values
+    /// into another — the regression a reintroduced per-record clone or a hoisted
+    /// buffer would cause.
+    #[test]
+    fn test_mods_do_not_leak_between_messages() {
+        let mut record = multi_mod_record();
+        record.mods = vec![
+            Mod {
+                keys: Some(r#"{"id":"1"}"#.to_owned()),
+                new_values: Some(r#"{"owner":"alice"}"#.to_owned()),
+                old_values: None,
+            },
+            Mod {
+                keys: Some(r#"{"id":"2"}"#.to_owned()),
+                // No `owner` at all for this row.
+                new_values: Some("{}".to_owned()),
+                old_values: None,
+            },
+        ];
+
+        let msgs = build_all(&record);
+        let first = payload_of(&msgs[0]);
+        let second = payload_of(&msgs[1]);
+
+        assert_eq!(
+            first["after"]["owner"],
+            serde_json::Value::String("alice".to_owned())
+        );
+        assert_eq!(second["after"]["id"], serde_json::Value::from(2));
+        assert!(
+            second["after"].get("owner").is_none(),
+            "second row must not inherit the first row's values, got {second}"
+        );
     }
 }

--- a/src/connector/src/source/spanner_cdc/source/reader.rs
+++ b/src/connector/src/source/spanner_cdc/source/reader.rs
@@ -56,7 +56,7 @@ use time::OffsetDateTime;
 use tokio::sync::mpsc;
 use tokio_retry::strategy::{ExponentialBackoff, jitter};
 
-use super::TaggedChangeRecord;
+use super::{ChangeRecordContext, build_source_message};
 use crate::error::{ConnectorError, ConnectorResult as Result};
 use crate::parser::ParserConfig;
 use crate::source::cdc::DebeziumCdcMeta;
@@ -854,16 +854,20 @@ async fn execute_query(
                     }
                 }
 
-                for modification in &data_change.mods {
-                    let tagged = TaggedChangeRecord {
-                        split_id: split_id.clone(),
-                        database_name: database.to_owned(),
-                        data_change: data_change.clone(),
-                        modification: modification.clone(),
-                    };
-                    let mut msg = SourceMessage::from(tagged);
-                    msg.offset = offset_str.clone();
-                    messages.push(msg);
+                // Column types and the rest of the record header are the same for every
+                // mod, so derive them once per record instead of once per row. Skipped
+                // entirely for records that carry no mods (e.g. schema-change only).
+                if !data_change.mods.is_empty() {
+                    let column_types = data_change.column_type_map();
+                    let ctx = ChangeRecordContext::new(database, data_change, &column_types);
+                    for modification in &data_change.mods {
+                        messages.push(build_source_message(
+                            split_id,
+                            &ctx,
+                            modification,
+                            &offset_str,
+                        ));
+                    }
                 }
             }
 

--- a/src/connector/src/source/spanner_cdc/types.rs
+++ b/src/connector/src/source/spanner_cdc/types.rs
@@ -22,6 +22,8 @@
 //!
 //! Reference: <https://cloud.google.com/spanner/docs/change-streams/details>
 
+use std::collections::HashMap;
+
 use parse_display::{Display, FromStr};
 use risingwave_common::types::{DataType, ListType};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -637,21 +639,16 @@ impl Mod {
     /// Note: `_rw_offset` and `_rw_table_name` are separate SOURCE columns,
     /// not part of the payload JSON.
     ///
-    /// The `data_change_record` parameter provides column type information to correctly
+    /// The `column_types` parameter provides column type information to correctly
     /// convert values (e.g., keep zipcode "02101" as string, not convert to number 2101).
+    /// It is shared by every `Mod` of the same `DataChangeRecord`, so the caller builds
+    /// it once per record via [`DataChangeRecord::column_type_map`] rather than per mod.
     pub fn to_json_map(
         &self,
         mod_type: &str,
-        data_change_record: &DataChangeRecord,
+        column_types: &HashMap<&str, TypeCode>,
     ) -> Result<serde_json::Map<String, JsonValue>, serde_json::Error> {
         let mut result = serde_json::Map::new();
-
-        // Build a map of column name to type code for type-aware conversion
-        let column_types: std::collections::HashMap<String, TypeCode> = data_change_record
-            .column_types
-            .iter()
-            .map(|ct| (ct.name.clone(), ct.type_code()))
-            .collect();
 
         // Spanner change streams encode all values as JSON strings regardless of the
         // underlying column type. Convert numeric types (INT64, FLOAT64, etc.) back
@@ -719,14 +716,16 @@ impl Mod {
                 if let Some(k) = keys {
                     let keys_map: serde_json::Map<String, JsonValue> = serde_json::from_str(k)?;
                     for (key, value) in keys_map {
-                        merged.insert(key.clone(), convert_value(&key, value));
+                        let converted = convert_value(&key, value);
+                        merged.insert(key, converted);
                     }
                 }
 
                 if let Some(v) = values {
                     let values_map: serde_json::Map<String, JsonValue> = serde_json::from_str(v)?;
                     for (key, value) in values_map {
-                        merged.insert(key.clone(), convert_value(&key, value));
+                        let converted = convert_value(&key, value);
+                        merged.insert(key, converted);
                     }
                 }
 
@@ -790,6 +789,17 @@ impl DataChangeRecord {
     pub fn commit_time(&self) -> OffsetDateTime {
         self.commit_timestamp
     }
+
+    /// Column name -> type code, for [`Mod::to_json_map`].
+    ///
+    /// `column_types` is schema metadata shared by every `Mod` in the record, so this
+    /// must be built once per record and reused, not rebuilt per mod.
+    pub fn column_type_map(&self) -> HashMap<&str, TypeCode> {
+        self.column_types
+            .iter()
+            .map(|ct| (ct.name.as_str(), ct.type_code()))
+            .collect()
+    }
 }
 
 impl ChildPartitionsRecord {
@@ -801,5 +811,133 @@ impl ChildPartitionsRecord {
 impl HeartbeatRecord {
     pub fn heartbeat_time(&self) -> OffsetDateTime {
         self.timestamp
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn column(name: &str, code: TypeCode, is_primary_key: bool, ordinal: i64) -> ColumnType {
+        ColumnType {
+            name: name.to_owned(),
+            spanner_type: SpannerType::simple(code),
+            is_primary_key,
+            ordinal_position: ordinal,
+        }
+    }
+
+    /// A record with an INT64 primary key, an INT64 measure, and a STRING column
+    /// whose values look numeric (the zipcode case).
+    fn record_with_mods(mods: Vec<Mod>) -> DataChangeRecord {
+        DataChangeRecord {
+            commit_timestamp: OffsetDateTime::from_unix_timestamp(1_700_000_000).unwrap(),
+            record_sequence: "0".to_owned(),
+            server_transaction_id: "txn-1".to_owned(),
+            is_last_record_in_transaction_in_partition: true,
+            table_name: "accounts".to_owned(),
+            value_capture_type: "OLD_AND_NEW_VALUES".to_owned(),
+            column_types: vec![
+                column("id", TypeCode::Int64, true, 1),
+                column("balance", TypeCode::Int64, false, 2),
+                column("zipcode", TypeCode::String, false, 3),
+            ],
+            mods,
+            mod_type: "INSERT".to_owned(),
+            number_of_records_in_transaction: 1,
+            number_of_partitions_in_transaction: 1,
+            transaction_tag: String::new(),
+            is_system_transaction: false,
+        }
+    }
+
+    fn insert_mod(id: i64, balance: i64, zipcode: &str) -> Mod {
+        Mod {
+            keys: Some(format!(r#"{{"id":"{id}"}}"#)),
+            new_values: Some(format!(
+                r#"{{"balance":"{balance}","zipcode":"{zipcode}"}}"#
+            )),
+            old_values: None,
+        }
+    }
+
+    /// The map must carry every column, with the same type codes the old
+    /// per-mod construction produced.
+    #[test]
+    fn test_column_type_map_covers_all_columns() {
+        let record = record_with_mods(vec![]);
+        let map = record.column_type_map();
+
+        assert_eq!(map.len(), record.column_types.len());
+        for ct in &record.column_types {
+            assert_eq!(
+                map.get(ct.name.as_str()),
+                Some(&ct.type_code()),
+                "column {} missing or mistyped",
+                ct.name
+            );
+        }
+    }
+
+    /// Guards the refactor that hoisted the column-type map out of `to_json_map`:
+    /// a map built once per record must produce byte-identical output to one built
+    /// fresh for every mod.
+    #[test]
+    fn test_to_json_map_shared_map_matches_fresh_map() {
+        let record = record_with_mods(vec![
+            insert_mod(1, 100, "02101"),
+            insert_mod(2, 200, "94103"),
+            insert_mod(3, 300, "10001"),
+        ]);
+        let shared = record.column_type_map();
+
+        for m in &record.mods {
+            let fresh: HashMap<&str, TypeCode> = record
+                .column_types
+                .iter()
+                .map(|ct| (ct.name.as_str(), ct.type_code()))
+                .collect();
+
+            let with_shared = m.to_json_map(&record.mod_type, &shared).unwrap();
+            let with_fresh = m.to_json_map(&record.mod_type, &fresh).unwrap();
+
+            assert_eq!(with_shared, with_fresh);
+        }
+    }
+
+    /// The map is what drives numeric coercion, so pin the actual conversion too:
+    /// INT64 columns become JSON numbers, STRING columns stay strings even when
+    /// their contents look numeric.
+    #[test]
+    fn test_to_json_map_applies_column_types() {
+        let record = record_with_mods(vec![insert_mod(7, 4200, "02101")]);
+        let map = record.column_type_map();
+
+        let json = record.mods[0].to_json_map(&record.mod_type, &map).unwrap();
+
+        assert_eq!(json["op"], JsonValue::String("c".to_owned()));
+        assert_eq!(json["before"], JsonValue::Null);
+        let after = json["after"].as_object().unwrap();
+        assert_eq!(after["id"], JsonValue::from(7));
+        assert_eq!(after["balance"], JsonValue::from(4200));
+        // Leading zero must survive: STRING column, not a number.
+        assert_eq!(after["zipcode"], JsonValue::String("02101".to_owned()));
+    }
+
+    /// An empty type map (record carried no `column_types`) must not coerce
+    /// anything, and must not error.
+    #[test]
+    fn test_to_json_map_without_column_types() {
+        let map: HashMap<&str, TypeCode> = HashMap::new();
+        let m = insert_mod(1, 100, "02101");
+
+        let json = m.to_json_map("INSERT", &map).unwrap();
+        let after = json["after"].as_object().unwrap();
+        assert_eq!(after["id"], JsonValue::String("1".to_owned()));
+        assert_eq!(after["balance"], JsonValue::String("100".to_owned()));
     }
 }


### PR DESCRIPTION
## Problem

Spanner sends changes in batches. One `DataChangeRecord` = a header plus a list of changed rows:

```
DataChangeRecord
├── table_name:        "accounts"      ─┐
├── mod_type:          "INSERT"         │  the header —
├── commit_timestamp:  ...              │  one copy, shared
├── column_types:      [id, owner, …]  ─┘
└── mods: [ row1, row2, row3, … ]         the rows — one each
```

RisingWave turns each row into one `SourceMessage`, and each message needs a bit of the header (the table name, the timestamp, the column types).

For each modification in a Spanner `DataChangeRecord`, the reader built a `TaggedChangeRecord` that owned a full clone of the record:

```rust
for modification in &data_change.mods {
    let tagged = TaggedChangeRecord {
        data_change: data_change.clone(),   // clones the entire `mods` vector
        modification: modification.clone(),
        ...
    };
}
```

`DataChangeRecord` owns `mods: Vec<Mod>`, and each `Mod` holds three `Option<String>` of raw JSON — the record's actual payload. So a record with N modifications copied its full payload N times: **O(N²) bytes**.

That work is entirely wasted. `mods` is never read downstream — the conversion touches only `commit_timestamp`, `mod_type`, `table_name`, and `column_types`.

`Mod::to_json_map` compounded it by rebuilding the column-name → type-code map, with a `String` clone per column, on every call — once per mod, for data that is per-record schema metadata.

This runs inside the `tokio::spawn`'d partition-reader task, which sits outside the per-actor `stream_actor_poll_duration` instrumentation, so the cost does not show up in actor-level metrics.

## Change

Replace the owned `TaggedChangeRecord` with a borrowed `ChangeRecordContext`, built once per record and shared by every mod:

```rust
let column_types = data_change.column_type_map();
let ctx = ChangeRecordContext::new(database, data_change, &column_types);
for modification in &data_change.mods {
    messages.push(build_source_message(split_id, &ctx, modification, &offset_str));
}
```

Also in this change:

- `DataChangeRecord::column_type_map()` derives the type map once per record; `to_json_map` now takes `&HashMap<&str, TypeCode>`.
- Dropped a redundant `key.clone()` in `merge_keys_and_values` — the key is already owned, so convert first and move it in.
- `offset` is passed in rather than built from the commit timestamp and immediately overwritten by the caller.
- Records carrying no mods (schema-change only) skip the path entirely.

Per record with N mods and C columns: the O(N²) payload copy is gone, and the per-mod O(C) allocations collapse to O(C) once. What remains per mod is the necessary work — parsing `keys`/`new_values`/`old_values` and serializing the envelope.

## Compatibility

No behavior change. Output is byte-identical: same envelope nesting, same `source.db` / `source.table` / `source.ts_ms`, same `offset`, same `DebeziumCdcMeta`. The map's key type changed from `String` to `&str`; lookups resolve through `Borrow<str>` in both cases, so hashing and equality are unchanged.

Not user-facing — no SQL, connector option, or config surface is touched.