### PR TITLE
feat(connector): support gs:// schema.location with ADC auth

### DIFF
--- a/src/connector/src/gcs_utils.rs
+++ b/src/connector/src/gcs_utils.rs
@@ -1,0 +1,107 @@
+// Copyright 2025 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::{Context, anyhow};
+use opendal::Operator;
+use opendal::layers::{LoggingLayer, RetryLayer};
+use opendal::services::Gcs;
+use url::Url;
+
+use crate::error::ConnectorResult;
+
+/// Split a `gs://bucket/path/to/file` url into its bucket and object key.
+fn parse_gcs_url(location: &Url) -> ConnectorResult<(&str, &str)> {
+    let bucket = location
+        .host_str()
+        .with_context(|| format!("illegal file path {}", location))?;
+    let key = location
+        .path()
+        .strip_prefix('/')
+        .ok_or_else(|| anyhow!("gcs url {location} should have a '/' at the start of path."))?;
+    Ok((bucket, key))
+}
+
+/// Load a schema file from Google Cloud Storage.
+///
+/// Location format: `gs://bucket_name/path/to/file` (`gcs://` is also accepted).
+///
+/// Authentication uses Application Default Credentials (ADC). No credential is
+/// configured explicitly: opendal's `GoogleCredentialLoader` resolves it from
+/// `GOOGLE_APPLICATION_CREDENTIALS`, the well-known gcloud config file
+/// (`~/.config/gcloud/application_default_credentials.json`), or the GCE/GKE
+/// metadata server (i.e. Workload Identity). No HMAC key is required.
+pub async fn load_file_descriptor_from_gcs(location: &Url) -> ConnectorResult<Vec<u8>> {
+    let (bucket, key) = parse_gcs_url(location)?;
+
+    let builder = Gcs::default().bucket(bucket);
+
+    let op: Operator = Operator::new(builder)?
+        .layer(LoggingLayer::default())
+        .layer(RetryLayer::default())
+        .finish();
+
+    let bytes = op
+        .read(key)
+        .await
+        .with_context(|| format!("failed to get file from gcs at `{}`", location))?;
+
+    Ok(bytes.to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_gcs_url() {
+        let url = Url::parse("gs://my-bucket/path/to/schema.avsc").unwrap();
+        assert_eq!(
+            parse_gcs_url(&url).unwrap(),
+            ("my-bucket", "path/to/schema.avsc")
+        );
+
+        // `gcs://` is accepted as well.
+        let url = Url::parse("gcs://my-bucket/schema.proto").unwrap();
+        assert_eq!(parse_gcs_url(&url).unwrap(), ("my-bucket", "schema.proto"));
+
+        // Bucket names may contain dots.
+        let url = Url::parse("gs://my.bucket.example/a/b.avsc").unwrap();
+        assert_eq!(
+            parse_gcs_url(&url).unwrap(),
+            ("my.bucket.example", "a/b.avsc")
+        );
+    }
+
+    /// Fetch a real object from GCS using Application Default Credentials.
+    ///
+    /// Set `RW_TEST_GCS_URL` to a readable `gs://bucket/object` and run with:
+    /// `cargo test -p risingwave_connector --lib gcs_utils -- --ignored`
+    ///
+    /// Note that ADC here must resolve to a service account, an impersonated
+    /// service account, an external account, or a metadata server. Plain user
+    /// credentials from `gcloud auth application-default login` are of type
+    /// `authorized_user`, which opendal's credential loader does not support.
+    #[ignore]
+    #[tokio::test]
+    async fn test_load_file_descriptor_from_gcs_with_adc() {
+        let Ok(raw) = std::env::var("RW_TEST_GCS_URL") else {
+            panic!("RW_TEST_GCS_URL must be set to a readable gs:// object");
+        };
+        let url = Url::parse(&raw).unwrap();
+
+        let bytes = load_file_descriptor_from_gcs(&url).await.unwrap();
+
+        assert!(!bytes.is_empty());
+    }
+}

--- a/src/connector/src/gcs_utils.rs
+++ b/src/connector/src/gcs_utils.rs
@@ -34,7 +34,7 @@ fn parse_gcs_url(location: &Url) -> ConnectorResult<(&str, &str)> {
 
 /// Load a schema file from Google Cloud Storage.
 ///
-/// Location format: `gs://bucket_name/path/to/file` (`gcs://` is also accepted).
+/// Location format: `gs://bucket_name/path/to/file`.
 ///
 /// Authentication uses Application Default Credentials (ADC). No credential is
 /// configured explicitly: opendal's `GoogleCredentialLoader` resolves it from
@@ -71,8 +71,7 @@ mod tests {
             ("my-bucket", "path/to/schema.avsc")
         );
 
-        // `gcs://` is accepted as well.
-        let url = Url::parse("gcs://my-bucket/schema.proto").unwrap();
+        let url = Url::parse("gs://my-bucket/schema.proto").unwrap();
         assert_eq!(parse_gcs_url(&url).unwrap(), ("my-bucket", "schema.proto"));
 
         // Bucket names may contain dots.

--- a/src/connector/src/lib.rs
+++ b/src/connector/src/lib.rs
@@ -40,6 +40,7 @@ use duration_str::parse_std;
 use serde::de;
 
 pub mod aws_utils;
+pub mod gcs_utils;
 
 pub mod allow_alter_on_fly_fields;
 

--- a/src/connector/src/parser/config.rs
+++ b/src/connector/src/parser/config.rs
@@ -329,7 +329,7 @@ pub struct AvroProperties {
 /// WIP: may cover protobuf and json schema later.
 #[derive(Debug, Clone)]
 pub enum SchemaLocation {
-    /// Avsc from `https://`, `s3://` or `file://`.
+    /// Avsc from `https://`, `s3://`, `gs://` or `file://`.
     File {
         url: String,
         aws_auth_props: Option<AwsAuthProps>, // for s3

--- a/src/connector/src/parser/utils.rs
+++ b/src/connector/src/parser/utils.rs
@@ -24,6 +24,7 @@ use risingwave_pb::data::DataType as PbDataType;
 use crate::aws_utils::load_file_descriptor_from_s3;
 use crate::connector_common::AwsAuthProps;
 use crate::error::ConnectorResult;
+use crate::gcs_utils::load_file_descriptor_from_gcs;
 use crate::source::SourceMeta;
 
 macro_rules! log_error {
@@ -97,6 +98,8 @@ macro_rules! only_parse_payload {
 /// * local file, for on-premise or testing.
 /// * http/https, for common usage.
 /// * s3 file location format: <s3://bucket_name/file_name>
+/// * gcs file location format: <gs://bucket_name/file_name>, authenticated with
+///   Application Default Credentials (ADC), so no HMAC key is needed.
 pub(super) async fn bytes_from_url(
     url: &Url,
     config: Option<&AwsAuthProps>,
@@ -113,6 +116,7 @@ pub(super) async fn bytes_from_url(
         }
         ("https" | "http", _) => Ok(download_from_http(url).await?.into()),
         ("s3", Some(config)) => load_file_descriptor_from_s3(url, config).await,
+        ("gs" | "gcs", _) => load_file_descriptor_from_gcs(url).await,
         (scheme, _) => bail!("path scheme `{scheme}` is not supported"),
     }
 }

--- a/src/connector/src/parser/utils.rs
+++ b/src/connector/src/parser/utils.rs
@@ -116,7 +116,7 @@ pub(super) async fn bytes_from_url(
         }
         ("https" | "http", _) => Ok(download_from_http(url).await?.into()),
         ("s3", Some(config)) => load_file_descriptor_from_s3(url, config).await,
-        ("gs" | "gcs", _) => load_file_descriptor_from_gcs(url).await,
+        ("gs", _) => load_file_descriptor_from_gcs(url).await,
         (scheme, _) => bail!("path scheme `{scheme}` is not supported"),
     }
 }


### PR DESCRIPTION
Adds `gs://` to the `schema.location` scheme dispatcher, authenticated via Application Default Credentials.

Previously the only object-store option was `s3://`, which against GCS requires the interoperability endpoint and long-lived HMAC keys. RisingWave already reads its Hummock state store from GCS over ADC, so the credentials were available — just not reachable from the schema-loading path.

## Changes

- **`connector/src/gcs_utils.rs`** (new) — `load_file_descriptor_from_gcs()`, mirroring `aws_utils::load_file_descriptor_from_s3`. Builds an OpenDAL `Gcs` operator without calling `.credential()`, so reqsign resolves ADC (env var → gcloud well-known file → GCE/GKE metadata server).
- **`connector/src/parser/utils.rs`** — new arm: `("gs", _) => load_file_descriptor_from_gcs(url).await`
- **`connector/src/lib.rs`** — `pub mod gcs_utils;`
- **`connector/src/parser/config.rs`** — doc comment

No dependency change: `services-gcs` was already enabled in `connector/Cargo.toml`.

Only `gs://` is accepted — the canonical Google spelling — rather than also aliasing `gcs://`, so there is exactly one valid way to write a GCS location. The credential slot is `_` rather than `Some(config)` so the arm can't fall through to the catch-all and report "scheme not supported" for a scheme that is supported.

Avro, Protobuf and JSON `schema.location` all gain this from the single dispatch arm — `json_parser.rs` calls `bytes_from_url(url, None)`, and the guard in `schema/protobuf.rs` only rejects `s3`, so protobuf sinks work too.

## Testing

- `cargo check -p risingwave_connector --lib` — 0 errors
- `cargo test -p risingwave_connector --lib gcs_utils` — unit test for URL parsing
- `cargo clippy -p risingwave_connector --lib --all-targets` — no new findings
- Real GCS fetch verified end to end with a service-account key
- Metadata-server ADC verified in a GKE cluster (HTTP 200 for the deployed RisingWave GSA, no HMAC key)

The end-to-end test is `#[ignore]`d and reads its target from `RW_TEST_GCS_URL`, so it never runs in CI:

```
GOOGLE_APPLICATION_CREDENTIALS=/path/to/sa.json \
RW_TEST_GCS_URL="gs://bucket/object" \
cargo test -p risingwave_connector --lib gcs_utils -- --ignored --nocapture
```

## Known limitation

reqsign 0.16.5 supports `service_account`, `impersonated_service_account` and `external_account`, but **not** `authorized_user` — the type written by `gcloud auth application-default login`. With only user credentials the loader skips the well-known file, falls through to the metadata server, and fails with a DNS error for `metadata.google.internal`, which is a confusing message for an unsupported credential type. For local development use a service-account key or `--impersonate-service-account`. Workload Identity in a cluster is unaffected.
