### PR TITLE
feat(meta): let auto schema change sinks key on columns outside the table pk

### DIFF
--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -474,7 +474,14 @@ impl StreamSink {
                 .iter()
                 .map(|&column_index| columns[column_index].name())
                 .collect_vec();
-            if upstream_table_pk_col_names != sink_pk_col_names {
+            // The sink pk only has to *cover* the upstream pk. Those columns cannot be dropped
+            // from the table, so indices derived from them stay resolvable across a schema
+            // change; any extra column the sink keys on is caught when the refresh remaps
+            // `downstream_pk` and finds it gone.
+            let covers_upstream_pk = upstream_table_pk_col_names
+                .iter()
+                .all(|name| sink_pk_col_names.contains(name));
+            if !covers_upstream_pk {
                 let is_iceberg_row_id_alias = properties.is_iceberg_connector()
                     && upstream_table_pk_col_names.len() == 1
                     && upstream_table_pk_col_names[0] == ROW_ID_COLUMN_NAME
@@ -482,7 +489,7 @@ impl StreamSink {
                     && sink_pk_col_names[0] == RISINGWAVE_ICEBERG_ROW_ID;
                 if !is_iceberg_row_id_alias {
                     return Err(ErrorCode::InvalidInputSyntax(format!(
-                        "sink with auto schema change should have same pk as upstream table {:?}, but got {:?}",
+                        "sink with auto schema change must cover the pk of upstream table {:?}, but got {:?}",
                         upstream_table_pk_col_names, sink_pk_col_names
                     ))
                     .into());

--- a/src/meta/src/controller/streaming_job.rs
+++ b/src/meta/src/controller/streaming_job.rs
@@ -2202,14 +2202,17 @@ impl CatalogController {
                         .one(txn)
                         .await?;
                 let columns = ColumnCatalogArray::from(finish_sink_context.columns);
+                let downstream_pk = I32Array::from(finish_sink_context.downstream_pk);
                 Sink::update(sink::ActiveModel {
                     sink_id: Set(finish_sink_context.original_sink_id),
                     columns: Set(columns.clone()),
+                    downstream_pk: Set(downstream_pk.clone()),
                     ..Default::default()
                 })
                 .exec(txn)
                 .await?;
                 sink.columns = columns;
+                sink.downstream_pk = downstream_pk;
                 objects.push(PbObject {
                     object_info: Some(PbObjectInfo::Sink(
                         ObjectModel(sink, sink_obj.unwrap(), sink_streaming_job.clone()).into(),
@@ -3847,6 +3850,7 @@ pub struct FinishAutoRefreshSchemaSinkContext {
     pub tmp_sink_id: SinkId,
     pub original_sink_id: SinkId,
     pub columns: Vec<PbColumnCatalog>,
+    pub downstream_pk: Vec<i32>,
     pub new_log_store_table: Option<Box<PbTable>>,
 }
 

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -1718,7 +1718,7 @@ impl DdlController {
                     let sink_ctx = sink_job_fragments.ctx;
                     let original_sink_fragment =
                         sink_job_fragments.fragments.into_values().next().unwrap();
-                    let (new_sink_fragment, new_schema, new_log_store_table) =
+                    let (new_sink_fragment, new_schema, new_log_store_table, new_downstream_pk) =
                         rewrite_refresh_schema_sink_fragment(
                             &original_sink_fragment,
                             &sink,
@@ -1746,6 +1746,7 @@ impl DdlController {
                         original_sink: sink,
                         original_fragment: original_sink_fragment,
                         new_schema,
+                        new_downstream_pk,
                         newly_add_fields: newly_added_columns
                             .iter()
                             .map(|col| Field::from(&col.column_desc))
@@ -1810,6 +1811,7 @@ impl DdlController {
                             tmp_sink_id: sink.tmp_sink_id,
                             original_sink_id: sink.original_sink.id,
                             columns: sink.new_schema.clone(),
+                            downstream_pk: sink.new_downstream_pk.clone(),
                             new_log_store_table: sink.new_log_store_table.clone(),
                         })
                         .collect()

--- a/src/meta/src/stream/stream_graph/fragment.rs
+++ b/src/meta/src/stream/stream_graph/fragment.rs
@@ -752,7 +752,7 @@ pub fn rewrite_refresh_schema_sink_fragment(
     upstream_table: &PbTable,
     upstream_table_fragment_id: FragmentId,
     id_generator_manager: &IdGeneratorManager,
-) -> MetaResult<(Fragment, Vec<PbColumnCatalog>, Option<PbTable>)> {
+) -> MetaResult<(Fragment, Vec<PbColumnCatalog>, Option<PbTable>, Vec<i32>)> {
     let removed_column_ids: HashSet<_> =
         removed_columns.iter().map(|col| col.column_id()).collect();
     let removed_log_store_column_names: HashSet<_> = removed_columns
@@ -765,6 +765,36 @@ pub fn rewrite_refresh_schema_sink_fragment(
         .collect();
     let new_sink_columns =
         build_new_sink_columns(sink, &removed_sink_column_names, newly_added_columns);
+
+    // `downstream_pk` indexes into the sink's column list, which `build_new_sink_columns`
+    // compacts when a column is dropped, so the stored indices go stale as soon as anything
+    // before a pk column disappears. Re-resolve them through the sink's own column ids, which
+    // `extend_sink_columns` keeps unique. A pk column that is gone entirely has no new index,
+    // and rekeying the sink silently would corrupt the downstream table, so that fails here.
+    let new_index_of_column_id: HashMap<i32, usize> = new_sink_columns
+        .iter()
+        .enumerate()
+        .map(|(index, col)| (col.column_desc.as_ref().unwrap().column_id, index))
+        .collect();
+    let new_downstream_pk = sink
+        .downstream_pk
+        .iter()
+        .map(|&index| {
+            let column_desc = sink.columns[index as usize].column_desc.as_ref().unwrap();
+            new_index_of_column_id
+                .get(&column_desc.column_id)
+                .map(|&index| index as i32)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "cannot drop column {} of table {}: it is part of the primary key of sink {}",
+                        column_desc.name,
+                        upstream_table.name,
+                        sink.name,
+                    )
+                    .into()
+                })
+        })
+        .collect::<MetaResult<Vec<_>>>()?;
 
     let mut new_sink_fragment = clone_fragment(original_sink_fragment, id_generator_manager);
     let sink_node = &mut new_sink_fragment.nodes;
@@ -821,7 +851,11 @@ pub fn rewrite_refresh_schema_sink_fragment(
     } else {
         None
     };
-    sink_node_body.sink_desc.as_mut().unwrap().column_catalogs = new_sink_columns.clone();
+    let new_sink_desc = sink_node_body.sink_desc.as_mut().unwrap();
+    new_sink_desc.column_catalogs = new_sink_columns.clone();
+    // The executor rebuilds `SinkParam` from `sink_desc`, so the remapped pk has to land here
+    // as well as on the catalog; these are two independent copies of the same indices.
+    new_sink_desc.downstream_pk = new_downstream_pk.iter().map(|&index| index as u32).collect();
 
     let stream_scan_node = if stream_input_is_project {
         let [stream_scan_node] = stream_input_node.input.as_mut_slice() else {
@@ -858,7 +892,12 @@ pub fn rewrite_refresh_schema_sink_fragment(
     } else {
         sink_node.fields = scan_rewrite.output_fields;
     }
-    Ok((new_sink_fragment, new_sink_columns, new_log_store_table))
+    Ok((
+        new_sink_fragment,
+        new_sink_columns,
+        new_log_store_table,
+        new_downstream_pk,
+    ))
 }
 
 /// Adjacency list (G) of backfill orders.
@@ -2444,7 +2483,7 @@ mod tests {
             },
         };
 
-        let (new_fragment, _, _) = rewrite_refresh_schema_sink_fragment(
+        let (new_fragment, _, _, _) = rewrite_refresh_schema_sink_fragment(
             &original_fragment,
             &sink,
             std::slice::from_ref(&new_column),
@@ -2492,6 +2531,136 @@ mod tests {
         assert_eq!(
             stream_scan_node.fields.last().unwrap().name,
             format!("{}.{}", table_name, new_column.column_desc.name)
+        );
+    }
+
+    /// Builds an upsert sink over `columns` whose `downstream_pk` is `pk_indices`, then drops
+    /// `removed`. Returns the sink fragment's remapped `downstream_pk`.
+    async fn rewrite_dropping_column(
+        columns: &[ColumnCatalog],
+        pk_indices: Vec<i32>,
+        removed: &ColumnCatalog,
+    ) -> MetaResult<(Vec<i32>, Vec<u32>)> {
+        let env = MetaSrvEnv::for_test().await;
+        let id_gen_manager = env.id_gen_manager().as_ref();
+        let table_name = "t";
+
+        let surviving = columns
+            .iter()
+            .filter(|col| col.column_id() != removed.column_id())
+            .cloned()
+            .collect_vec();
+        let upstream_table = PbTable {
+            name: table_name.to_owned(),
+            columns: surviving.iter().map(|col| col.to_protobuf()).collect(),
+            ..Default::default()
+        };
+
+        let sink = PbSink {
+            name: "s".to_owned(),
+            columns: columns.iter().map(|col| col.to_protobuf()).collect(),
+            downstream_pk: pk_indices,
+            sink_type: PbSinkType::Upsert as i32,
+            ..Default::default()
+        };
+        let sink_desc = SinkDesc {
+            sink_type: PbSinkType::Upsert as i32,
+            column_catalogs: sink.columns.clone(),
+            downstream_pk: sink.downstream_pk.iter().map(|&i| i as u32).collect(),
+            ..Default::default()
+        };
+
+        let stream_scan_node = make_stream_scan_node(table_name, 1, columns);
+        let project_node = make_project_node(table_name, columns, stream_scan_node);
+        let log_store_table = PbTable {
+            columns: columns
+                .iter()
+                .cloned()
+                .map(|mut col| {
+                    col.column_desc.name = format!("{}_{}", table_name, col.column_desc.name);
+                    col.to_protobuf()
+                })
+                .collect(),
+            value_indices: (0..columns.len()).map(|i| i as i32).collect(),
+            ..Default::default()
+        };
+        let original_fragment = Fragment {
+            fragment_id: 1.into(),
+            fragment_type_mask: FragmentTypeMask::default(),
+            distribution_type: PbFragmentDistributionType::Single,
+            state_table_ids: vec![],
+            maybe_vnode_count: None,
+            nodes: StreamNode {
+                node_body: Some(NodeBody::Sink(Box::new(SinkNode {
+                    sink_desc: Some(sink_desc),
+                    table: Some(log_store_table),
+                    log_store_type: SinkLogStoreType::KvLogStore as i32,
+                    ..Default::default()
+                }))),
+                fields: columns
+                    .iter()
+                    .map(|col| make_field(table_name, col))
+                    .collect(),
+                input: vec![project_node],
+                ..Default::default()
+            },
+        };
+
+        let (new_fragment, _, _, new_downstream_pk) = rewrite_refresh_schema_sink_fragment(
+            &original_fragment,
+            &sink,
+            &[],
+            std::slice::from_ref(removed),
+            &upstream_table,
+            7.into(),
+            id_gen_manager,
+        )?;
+
+        let PbNodeBody::Sink(sink_body) = new_fragment.nodes.node_body.as_ref().unwrap() else {
+            panic!("expect sink node");
+        };
+        let desc_pk = sink_body.sink_desc.as_ref().unwrap().downstream_pk.clone();
+        Ok((new_downstream_pk, desc_pk))
+    }
+
+    /// Dropping a column positioned *before* a pk column shifts every later index down. Without
+    /// remapping, `downstream_pk` keeps pointing at the old positions and the sink silently
+    /// upserts on the wrong columns.
+    #[tokio::test]
+    async fn test_rewrite_refresh_schema_sink_fragment_remaps_downstream_pk_after_drop() {
+        let columns = vec![
+            make_column("a", 1, DataType::Int64),
+            make_column("b", 2, DataType::Int64),
+            make_column("c", 3, DataType::Int64),
+        ];
+        // pk is (b, c) at indices 1 and 2; dropping `a` must move them to 0 and 1.
+        let (new_downstream_pk, desc_pk) =
+            rewrite_dropping_column(&columns, vec![1, 2], &columns[0].clone())
+                .await
+                .unwrap();
+
+        assert_eq!(new_downstream_pk, vec![0, 1]);
+        // The executor reads `sink_desc`, so both copies have to agree.
+        assert_eq!(desc_pk, vec![0, 1]);
+    }
+
+    /// A pk column that is dropped outright has no new index. Rekeying the sink silently would
+    /// corrupt the downstream table, so the schema change has to fail instead.
+    #[tokio::test]
+    async fn test_rewrite_refresh_schema_sink_fragment_rejects_dropping_pk_column() {
+        let columns = vec![
+            make_column("a", 1, DataType::Int64),
+            make_column("b", 2, DataType::Int64),
+            make_column("c", 3, DataType::Int64),
+        ];
+        // pk is (a, b); dropping `b` leaves the sink with no column to key on.
+        let err = rewrite_dropping_column(&columns, vec![0, 1], &columns[1].clone())
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("part of the primary key"),
+            "unexpected error: {err}"
         );
     }
 
@@ -2568,7 +2737,7 @@ mod tests {
             },
         };
 
-        let (new_fragment, new_schema, new_log_store_table) = rewrite_refresh_schema_sink_fragment(
+        let (new_fragment, new_schema, new_log_store_table, _) = rewrite_refresh_schema_sink_fragment(
             &original_fragment,
             &sink,
             &[],

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -234,6 +234,9 @@ pub struct AutoRefreshSchemaSinkContext {
     pub original_sink: PbSink,
     pub original_fragment: Fragment,
     pub new_schema: Vec<PbColumnCatalog>,
+    /// `downstream_pk` remapped onto `new_schema`; the stored indices shift whenever a column
+    /// before a pk column is dropped.
+    pub new_downstream_pk: Vec<i32>,
     pub newly_add_fields: Vec<Field>,
     pub removed_column_names: Vec<String>,
     pub new_fragment: Fragment,


### PR DESCRIPTION
## What's changed and what's your intention?

A sink with `auto.schema.change` previously had to declare **exactly** the upstream table's primary key. This prevented sinks whose downstream systems require a wider key.

The issue surfaced with a Doris sink partitioned by day. Doris merge-on-write requires the partition column to be part of the key, so the sink PK needs to include `created_at` in addition to the table's PK. However, `CREATE SINK` rejected this:

    sink with auto schema change should have same pk as upstream table
    ["group", "cat_id"], but got ["group", "cat_id", "created_at"]

While investigating this, a second pre-existing issue was found: **dropping a column positioned before a PK column can leave the sink keying on the wrong columns**, and can even leave a PK index out of bounds.

## Root cause

Both issues come from the same place. `downstream_pk` stores *indices* into the sink's column list. `build_new_sink_columns` compacts that list when a column is dropped, but the indices were never remapped. Throughout the refresh path, `downstream_pk` is only ever *read*, primarily to render the identity string.

Requiring `sink pk == table pk` happened to make this safe because a table's own PK columns cannot be dropped, so indices derived from them remain stable. This is a structural guard for index stability, rather than a statement about which keys are meaningful.

The rule that governs PK correctness — the upsert subset check in `StreamSink` — is separate and remains unchanged.

## What this PR does

- **Remaps `downstream_pk`** during schema refresh by resolving through the sink's own column IDs, which are kept unique by `extend_sink_columns`.
- **Updates both copies of the indices**: `sink_desc`, which the executor rebuilds `SinkParam` from, and the sink catalog.
- **Rejects the schema change** when a PK column is dropped, rather than silently rekeying the sink.
- **Relaxes the frontend check** from equality to coverage, now that the indices are maintained.

## Verification

`cargo check -p risingwave_meta -p risingwave_frontend --lib` — 0 errors.

Two new unit tests cover cases that the existing tests miss. The existing tests only drop a *trailing* column from an *append-only* sink, where `downstream_pk` is irrelevant.

| Test | Assertion |
|---|---|
| `..._remaps_downstream_pk_after_drop` | PK `(b,c)` at `[1,2]`, drop `a` → `[0,1]` in **both** index copies |
| `..._rejects_dropping_pk_column` | Dropping a column that is part of the sink PK returns an error |

Negative control — with the remap reverted to the previous pass-through, both new tests fail with exactly the stale-index bug:

    left:  [1, 2]     # stale indices; one is out of bounds in a 2-column list
    right: [0, 1]

The two pre-existing tests pass either way, confirming that they did not cover this case.

## Not yet verified

End-to-end behavior (barrier → executor rebuild → actual writes) is untested, as is `auto.schema.change` combined with a Doris partitioned table. That combination has never run anywhere.

Both scenarios need a build and deploy before production use.